### PR TITLE
Add builder methods to push or replace url with current request url including query params

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponse.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponse.java
@@ -500,6 +500,20 @@ public final class HtmxResponse {
         }
 
         /**
+         * Pushes the current request URL including query parameters into the history stack of the browser.
+         * If you want to supply your own URL, use {@link #pushUrl(String)} instead.
+         *
+         * @return the builder
+         * @see <a href="https://htmx.org/headers/hx-push/">HX-Push Response Header</a> documentation
+         * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState">history.pushState()</a>
+         */
+        public Builder pushUrl() {
+            this.pushUrl = "";
+            this.replaceUrl = null;
+            return this;
+        }
+
+        /**
          * Pushes a new URL into the history stack of the browser.
          * <p>
          * If you want to prevent the history stack from being updated, use {@link #preventHistoryUpdate()}.
@@ -535,6 +549,20 @@ public final class HtmxResponse {
          */
         public Builder refresh() {
             this.refresh = true;
+            return this;
+        }
+
+        /**
+         * Replace the most recent entry, i.e. the current URL, in the browser history stack with the current request
+         * URL including query parameters. If you want to supply your own URL, use {@link #replaceUrl(String)} instead.
+         *
+         * @return the builder
+         * @see <a href="https://htmx.org/headers/hx-replace-url/">HX-Replace-Url Response Header</a>
+         * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState">history.replaceState()</a>
+         */
+        public Builder replaceUrl() {
+            this.replaceUrl = "";
+            this.pushUrl = null;
             return this;
         }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptor.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -97,10 +98,10 @@ class HtmxViewHandlerInterceptor implements HandlerInterceptor {
 
         modelAndView.setView(toView(htmxResponse));
 
-        addHxHeaders(htmxResponse, response);
+        addHxHeaders(htmxResponse, request, response);
     }
 
-    private void addHxHeaders(HtmxResponse htmxResponse, HttpServletResponse response) {
+    private void addHxHeaders(HtmxResponse htmxResponse, HttpServletRequest request, HttpServletResponse response) {
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER, htmxResponse.getTriggersInternal());
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE, htmxResponse.getTriggersAfterSettleInternal());
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP, htmxResponse.getTriggersAfterSwapInternal());
@@ -113,10 +114,20 @@ class HtmxViewHandlerInterceptor implements HandlerInterceptor {
             }
         }
         if (htmxResponse.getReplaceUrl() != null) {
-            response.setHeader(HtmxResponseHeader.HX_REPLACE_URL.getValue(), htmxResponse.getReplaceUrl());
+            String url = htmxResponse.getReplaceUrl();
+            if (url.isEmpty()) {
+                // use current request URL including query params
+                url = ServletUriComponentsBuilder.fromRequest(request).toUriString();
+            }
+            response.setHeader(HtmxResponseHeader.HX_REPLACE_URL.getValue(), url);
         }
         if (htmxResponse.getPushUrl() != null) {
-            response.setHeader(HtmxResponseHeader.HX_PUSH_URL.getValue(), htmxResponse.getPushUrl());
+            String url = htmxResponse.getPushUrl();
+            if (url.isEmpty()) {
+                // use current request URL including query params
+                url = ServletUriComponentsBuilder.fromRequest(request).toUriString();
+            }
+            response.setHeader(HtmxResponseHeader.HX_PUSH_URL.getValue(), url);
         }
         if (htmxResponse.getRedirect() != null) {
             response.setHeader(HtmxResponseHeader.HX_REDIRECT.getValue(), htmxResponse.getRedirect());

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorController.java
@@ -37,6 +37,11 @@ public class HtmxViewHandlerInterceptorController {
         return HtmxResponse.builder().pushUrl("/path").build();
     }
 
+    @GetMapping("/hx-push-current-url")
+    public HtmxResponse hxPushUrlReturningCurrentUrl() {
+        return HtmxResponse.builder().pushUrl().build();
+    }
+
     @GetMapping("/hx-redirect")
     public HtmxResponse hxRedirect() {
         return HtmxResponse.builder().redirect("/path").build();
@@ -50,6 +55,11 @@ public class HtmxViewHandlerInterceptorController {
     @GetMapping("/hx-replace-url")
     public HtmxResponse hxReplaceUrl() {
         return HtmxResponse.builder().replaceUrl("/path").build();
+    }
+
+    @GetMapping("/hx-replace-current-url")
+    public HtmxResponse hxReplaceUrlReturningCurrentUrl() {
+        return HtmxResponse.builder().replaceUrl().build();
     }
 
     @GetMapping("/hx-reselect")

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorController.java
@@ -1,9 +1,5 @@
 package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.TreeMap;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +32,21 @@ public class HtmxViewHandlerInterceptorController {
         return HtmxResponse.builder().location("/path").build();
     }
 
+    @GetMapping("/hx-push-url")
+    public HtmxResponse hxPushUrl() {
+        return HtmxResponse.builder().pushUrl("/path").build();
+    }
+
+    @GetMapping("/hx-redirect")
+    public HtmxResponse hxRedirect() {
+        return HtmxResponse.builder().redirect("/path").build();
+    }
+
+    @GetMapping("/hx-refresh")
+    public HtmxResponse hxRefresh() {
+        return HtmxResponse.builder().refresh().build();
+    }
+
     @GetMapping("/hx-replace-url")
     public HtmxResponse hxReplaceUrl() {
         return HtmxResponse.builder().replaceUrl("/path").build();
@@ -59,6 +70,11 @@ public class HtmxViewHandlerInterceptorController {
                                .focusScroll(true);
 
         return HtmxResponse.builder().reswap(reswap).build();
+    }
+
+    @GetMapping("/hx-retarget")
+    public HtmxResponse hxRetarget() {
+        return HtmxResponse.builder().retarget("#target").build();
     }
 
     @GetMapping("/hx-trigger-after-settle-with-details")
@@ -107,6 +123,11 @@ public class HtmxViewHandlerInterceptorController {
                            .trigger("event1")
                            .trigger("event2")
                            .build();
+    }
+
+    @GetMapping("/prevent-history-update")
+    public HtmxResponse preventHistoryUpdate() {
+        return HtmxResponse.builder().preventHistoryUpdate().build();
     }
 
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorTest.java
@@ -33,6 +33,27 @@ public class HtmxViewHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxPushUrl() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-push-url"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "/path"));
+    }
+
+    @Test
+    public void testHxRedirect() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-redirect"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Redirect", "/path"));
+    }
+
+    @Test
+    public void testHxRefresh() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-refresh"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Refresh", "true"));
+    }
+
+    @Test
     public void testHxReplaceUrl() throws Exception {
         mockMvc.perform(get("/hvhi/hx-replace-url"))
                .andExpect(status().isOk())
@@ -51,6 +72,13 @@ public class HtmxViewHandlerInterceptorTest {
         mockMvc.perform(get("/hvhi/hx-reswap"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Reswap", "outerHTML transition:true focus-scroll:true swap:100ms settle:300ms scroll:#target:bottom show:#target:top"));
+    }
+
+    @Test
+    public void testHxRetarget() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-retarget"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Retarget", "#target"));
     }
 
     @Test
@@ -93,6 +121,14 @@ public class HtmxViewHandlerInterceptorTest {
         mockMvc.perform(get("/hvhi/hx-trigger-without-details"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Trigger", "event1,event2"));
+    }
+
+    @Test
+    public void testPreventHistoryUpdate() throws Exception {
+        mockMvc.perform(get("/hvhi/prevent-history-update"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "false"))
+               .andExpect(header().doesNotExist("HX-Replace-Url"));
     }
 
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewHandlerInterceptorTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.endsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -40,6 +41,15 @@ public class HtmxViewHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxPushUrlReturningCurrentUrl() throws Exception {
+        String url = "/hvhi/hx-push-current-url?p1=x&p2=y";
+
+        mockMvc.perform(get(url))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", endsWith(url)));
+    }
+
+    @Test
     public void testHxRedirect() throws Exception {
         mockMvc.perform(get("/hvhi/hx-redirect"))
                .andExpect(status().isOk())
@@ -58,6 +68,15 @@ public class HtmxViewHandlerInterceptorTest {
         mockMvc.perform(get("/hvhi/hx-replace-url"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Replace-Url", "/path"));
+    }
+
+    @Test
+    public void testHxReplaceUrlReturningCurrentUrl() throws Exception {
+        String url = "/hvhi/hx-replace-current-url?p1=x&p2=y";
+
+        mockMvc.perform(get(url))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", endsWith(url)));
     }
 
     @Test


### PR DESCRIPTION
@dsyer I also found this handy in the case of `HtmxResponse` as return type. So let's add it here first.