### PR TITLE
Use setHeader() instead of addHeader() to avoid multiple headers being set

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxRefreshHeaderAuthenticationEntryPoint.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxRefreshHeaderAuthenticationEntryPoint.java
@@ -25,7 +25,7 @@ public class HxRefreshHeaderAuthenticationEntryPoint implements AuthenticationEn
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.addHeader("HX-Refresh", "true");
+        response.setHeader("HX-Refresh", "true");
         forbiddenEntryPoint.commence(request, response, authException);
     }
 }


### PR DESCRIPTION
For some reason that I haven't figured out, the authentication entrypoint is called twice for me whenever a user isn't logged. Since the entrypoint uses `addHeader()` it will result in two `HX-Refresh` headers in the response, making htmx ignore the header.

Even though there's probably something wrong with my code, changing it to use `setHeader()` will work around this and make sure there is only one `HX-Refresh` header in the response, making htmx behave as it should.

And thank you for a great library!