### PR TITLE
[fix] warning: unknown enum constant When.MAYBE caused by missing JSR305 implementation

### DIFF
--- a/htmx-spring-boot/pom.xml
+++ b/htmx-spring-boot/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+            <version>3.0.2</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
This warning is caused by the javax.annotation.meta.When enum not being available to the runtime and org.springframework.lang.Nullable references this enum but it is not made available automatically.