### PR TITLE
Remove spring plugin repository 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,16 +148,6 @@
             -->
         </plugins>
     </build>
-    <!-- Should be removed once spring-asciidoctor-backends is in Maven Central -->
-    <!--
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestone</id>
-            <name>Spring Milestone Repository</name>
-            <url>https://repo.spring.io/milestone</url>
-        </pluginRepository>
-    </pluginRepositories>
-    -->
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
As mentioned on [Issue](https://github.com/wimdeblauwe/htmx-spring-boot/issues/112) the spring-asciidoctor-backends is now available on maven central so there is no need to keep the plugin repository.  So I have removed it from pom.xml.