### PR TITLE
Add missing annotations for response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [Response Headers Reference](https://htmx.org/reference/#response_headers) f
 The following annotations are currently supported:
 * [@HxLocation](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
+* [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)
 
 >**Note** Please refer to the related Javadoc to learn more about the available options.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ See [Response Headers Reference](https://htmx.org/reference/#response_headers) f
 
 The following annotations are currently supported:
 * [@HxLocation](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.html)
+* [@HxRedirect](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following annotations are currently supported:
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)
 * [@HxReswap](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.html)
+* [@HxRetarget](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRetarget.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)
 
 >**Note** Please refer to the related Javadoc to learn more about the available options.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The first is to use annotations, e.g. `@HxTrigger`, and the second is to use the
 See [Response Headers Reference](https://htmx.org/reference/#response_headers) for the related htmx documentation.
 
 The following annotations are currently supported:
+* [@HxLocation](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following annotations are currently supported:
 * [@HxRedirect](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)
+* [@HxReswap](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)
 
 >**Note** Please refer to the related Javadoc to learn more about the available options.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ See [Response Headers Reference](https://htmx.org/reference/#response_headers) f
 
 The following annotations are currently supported:
 * [@HxLocation](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.html)
+* [@HxPushUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxPushUrl.html)
 * [@HxRedirect](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following annotations are currently supported:
 * [@HxRedirect](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.html)
 * [@HxRefresh](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRefresh.html)
 * [@HxReplaceUrl](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.html)
+* [@HxReselect](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReselect.html)
 * [@HxReswap](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.html)
 * [@HxRetarget](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRetarget.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The following annotations are currently supported:
 * [@HxReswap](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.html)
 * [@HxRetarget](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRetarget.html)
 * [@HxTrigger](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTrigger.html)
+* [@HxTriggerAfterSettle](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSettle.html)
+* [@HxTriggerAfterSwap](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/latest/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSwap.html)
 
 >**Note** Please refer to the related Javadoc to learn more about the available options.
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -15,13 +15,24 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class HtmxHandlerInterceptor implements HandlerInterceptor {
+
+    private final ObjectMapper objectMapper;
+
+    public HtmxHandlerInterceptor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Override
     public boolean preHandle(HttpServletRequest request,
-                           HttpServletResponse response,
-                           Object handler) {
+                             HttpServletResponse response,
+                             Object handler) {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
+            setHxLocation(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
@@ -33,6 +44,18 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
     private void setVary(HttpServletRequest request, HttpServletResponse response) {
         if (request.getHeader(HtmxRequestHeader.HX_REQUEST.getValue()) != null) {
             response.addHeader(HttpHeaders.VARY, HtmxRequestHeader.HX_REQUEST.getValue());
+        }
+    }
+
+    private void setHxLocation(HttpServletResponse response, Method method) {
+        HxLocation methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxLocation.class);
+        if (methodAnnotation != null) {
+            var location = convertToLocation(methodAnnotation);
+            if (location.hasContextData()) {
+                setHeaderJsonValue(response, HtmxResponseHeader.HX_LOCATION.getValue(), location);
+            } else {
+                response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
+            }
         }
     }
 
@@ -61,5 +84,34 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             default:
                 throw new IllegalArgumentException("Unknown lifecycle:" + lifecycle);
         }
+    }
+
+    private void setHeaderJsonValue(HttpServletResponse response, String name, Object value) {
+        try {
+            response.setHeader(name, objectMapper.writeValueAsString(value));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to set header " + name + " to " + value, e);
+        }
+    }
+
+    private HtmxLocation convertToLocation(HxLocation annotation) {
+        var location = new HtmxLocation();
+        location.setPath(annotation.path());
+        if (!annotation.source().isEmpty()) {
+            location.setSource(annotation.source());
+        }
+        if (!annotation.event().isEmpty()) {
+            location.setEvent(annotation.event());
+        }
+        if (!annotation.handler().isEmpty()) {
+            location.setHandler(annotation.handler());
+        }
+        if (!annotation.target().isEmpty()) {
+            location.setTarget(annotation.target());
+        }
+        if (!annotation.target().isEmpty()) {
+            location.setSwap(annotation.swap());
+        }
+        return location;
     }
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -3,6 +3,7 @@ package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.*;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +34,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             setHxPushUrl(response, method);
             setHxRedirect(response, method);
             setHxReplaceUrl(response, method);
+            setHxReswap(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
@@ -77,6 +79,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         HxReplaceUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReplaceUrl.class);
         if (methodAnnotation != null) {
             response.setHeader(HX_REPLACE_URL.getValue(), methodAnnotation.value());
+        }
+    }
+
+    private void setHxReswap(HttpServletResponse response, Method method) {
+        HxReswap methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReswap.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_RESWAP.getValue(), convertToReswap(methodAnnotation));
         }
     }
 
@@ -135,4 +144,44 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         }
         return location;
     }
+
+    private String convertToReswap(HxReswap annotation) {
+
+        var reswap = new HtmxReswap(annotation.value());
+        if (annotation.swap() != -1) {
+            reswap.swap(Duration.ofMillis(annotation.swap()));
+        }
+        if (annotation.settle() != -1) {
+            reswap.swap(Duration.ofMillis(annotation.settle()));
+        }
+        if (annotation.transition()) {
+            reswap.transition();
+        }
+        if (annotation.focusScroll() != HxReswap.FocusScroll.UNDEFINED) {
+            reswap.focusScroll(annotation.focusScroll() == HxReswap.FocusScroll.TRUE);
+        }
+        if (annotation.show() != HxReswap.Position.UNDEFINED) {
+            reswap.show(convertToPosition(annotation.show()));
+            if (!annotation.showTarget().isEmpty()) {
+                reswap.scrollTarget(annotation.showTarget());
+            }
+        }
+        if (annotation.scroll() != HxReswap.Position.UNDEFINED) {
+            reswap.scroll(convertToPosition(annotation.scroll()));
+            if (!annotation.scrollTarget().isEmpty()) {
+                reswap.scrollTarget(annotation.scrollTarget());
+            }
+        }
+
+        return reswap.toString();
+    }
+
+    private HtmxReswap.Position convertToPosition(HxReswap.Position position) {
+        return switch (position) {
+            case TOP -> HtmxReswap.Position.TOP;
+            case BOTTOM -> HtmxReswap.Position.BOTTOM;
+            default -> throw new IllegalStateException("Unexpected value: " + position);
+        };
+    }
+
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -36,6 +36,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             setHxReplaceUrl(response, method);
             setHxReswap(response, method);
             setHxRetarget(response, method);
+            setHxReselect(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
@@ -94,6 +95,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         HxRetarget methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRetarget.class);
         if (methodAnnotation != null) {
             response.setHeader(HX_RETARGET.getValue(), methodAnnotation.value());
+        }
+    }
+
+    private void setHxReselect(HttpServletResponse response, Method method) {
+        HxReselect methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReselect.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_RESELECT.getValue(), methodAnnotation.value());
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -1,9 +1,6 @@
 package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 
-import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.HX_REFRESH;
-import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.HX_TRIGGER;
-import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE;
-import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP;
+import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.*;
 
 import java.lang.reflect.Method;
 
@@ -33,6 +30,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxLocation(response, method);
+            setHxReplaceUrl(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
@@ -56,6 +54,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             } else {
                 response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
             }
+        }
+    }
+
+    private void setHxReplaceUrl(HttpServletResponse response, Method method) {
+        HxReplaceUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReplaceUrl.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_REPLACE_URL.getValue(), methodAnnotation.value());
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -28,6 +28,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response,
                              Object handler) {
+
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxLocation(response, method);
@@ -38,6 +39,8 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             setHxRetarget(response, method);
             setHxReselect(response, method);
             setHxTrigger(response, method);
+            setHxTriggerAfterSettle(response, method);
+            setHxTriggerAfterSwap(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
         }
@@ -108,7 +111,21 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
     private void setHxTrigger(HttpServletResponse response, Method method) {
         HxTrigger methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTrigger.class);
         if (methodAnnotation != null) {
-            response.setHeader(getHeaderName(methodAnnotation.lifecycle()), methodAnnotation.value());
+            setHeader(response, getHeaderName(methodAnnotation.lifecycle()), methodAnnotation.value());
+        }
+    }
+
+    private void setHxTriggerAfterSettle(HttpServletResponse response, Method method) {
+        HxTriggerAfterSettle methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTriggerAfterSettle.class);
+        if (methodAnnotation != null) {
+            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE.getValue(), methodAnnotation.value());
+        }
+    }
+
+    private void setHxTriggerAfterSwap(HttpServletResponse response, Method method) {
+        HxTriggerAfterSwap methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTriggerAfterSwap.class);
+        if (methodAnnotation != null) {
+            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP.getValue(), methodAnnotation.value());
         }
     }
 
@@ -138,6 +155,10 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Unable to set header " + name + " to " + value, e);
         }
+    }
+
+    private void setHeader(HttpServletResponse response, String name, String[] values) {
+        response.setHeader(name, String.join(",", values));
     }
 
     private HtmxLocation convertToLocation(HxLocation annotation) {

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -30,6 +30,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxLocation(response, method);
+            setHxRedirect(response, method);
             setHxReplaceUrl(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
@@ -54,6 +55,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             } else {
                 response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
             }
+        }
+    }
+
+    private void setHxRedirect(HttpServletResponse response, Method method) {
+        HxRedirect methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRedirect.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_REDIRECT.getValue(), methodAnnotation.value());
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -59,9 +59,9 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         if (methodAnnotation != null) {
             var location = convertToLocation(methodAnnotation);
             if (location.hasContextData()) {
-                setHeaderJsonValue(response, HtmxResponseHeader.HX_LOCATION.getValue(), location);
+                setHeaderJsonValue(response, HtmxResponseHeader.HX_LOCATION, location);
             } else {
-                response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
+                setHeader(response, HtmxResponseHeader.HX_LOCATION, location.getPath());
             }
         }
     }
@@ -69,96 +69,100 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
     private void setHxPushUrl(HttpServletResponse response, Method method) {
         HxPushUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxPushUrl.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_PUSH_URL.getValue(), methodAnnotation.value());
+            setHeader(response, HX_PUSH_URL, methodAnnotation.value());
         }
     }
 
     private void setHxRedirect(HttpServletResponse response, Method method) {
         HxRedirect methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRedirect.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_REDIRECT.getValue(), methodAnnotation.value());
+            setHeader(response, HX_REDIRECT, methodAnnotation.value());
         }
     }
 
     private void setHxReplaceUrl(HttpServletResponse response, Method method) {
         HxReplaceUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReplaceUrl.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_REPLACE_URL.getValue(), methodAnnotation.value());
+            setHeader(response, HX_REPLACE_URL, methodAnnotation.value());
         }
     }
 
     private void setHxReswap(HttpServletResponse response, Method method) {
         HxReswap methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReswap.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_RESWAP.getValue(), convertToReswap(methodAnnotation));
+            setHeader(response, HX_RESWAP, convertToReswap(methodAnnotation));
         }
     }
 
     private void setHxRetarget(HttpServletResponse response, Method method) {
         HxRetarget methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRetarget.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_RETARGET.getValue(), methodAnnotation.value());
+            setHeader(response, HX_RETARGET, methodAnnotation.value());
         }
     }
 
     private void setHxReselect(HttpServletResponse response, Method method) {
         HxReselect methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReselect.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_RESELECT.getValue(), methodAnnotation.value());
+            setHeader(response, HX_RESELECT, methodAnnotation.value());
         }
     }
 
     private void setHxTrigger(HttpServletResponse response, Method method) {
         HxTrigger methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTrigger.class);
         if (methodAnnotation != null) {
-            setHeader(response, getHeaderName(methodAnnotation.lifecycle()), methodAnnotation.value());
+            setHeader(response, convertToHeader(methodAnnotation.lifecycle()), methodAnnotation.value());
         }
     }
 
     private void setHxTriggerAfterSettle(HttpServletResponse response, Method method) {
         HxTriggerAfterSettle methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTriggerAfterSettle.class);
         if (methodAnnotation != null) {
-            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE.getValue(), methodAnnotation.value());
+            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE, methodAnnotation.value());
         }
     }
 
     private void setHxTriggerAfterSwap(HttpServletResponse response, Method method) {
         HxTriggerAfterSwap methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxTriggerAfterSwap.class);
         if (methodAnnotation != null) {
-            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP.getValue(), methodAnnotation.value());
+            setHeader(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP, methodAnnotation.value());
         }
     }
 
     private void setHxRefresh(HttpServletResponse response, Method method) {
         HxRefresh methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRefresh.class);
         if (methodAnnotation != null) {
-            response.setHeader(HX_REFRESH.getValue(), "true");
+            setHeader(response, HX_REFRESH, HtmxValue.TRUE);
         }
     }
 
-    private String getHeaderName(HxTriggerLifecycle lifecycle) {
+    private HtmxResponseHeader convertToHeader(HxTriggerLifecycle lifecycle) {
         switch (lifecycle) {
             case RECEIVE:
-                return HX_TRIGGER.getValue();
+                return HX_TRIGGER;
             case SETTLE:
-                return HX_TRIGGER_AFTER_SETTLE.getValue();
+                return HX_TRIGGER_AFTER_SETTLE;
             case SWAP:
-                return HX_TRIGGER_AFTER_SWAP.getValue();
+                return HX_TRIGGER_AFTER_SWAP;
             default:
                 throw new IllegalArgumentException("Unknown lifecycle:" + lifecycle);
         }
     }
 
-    private void setHeaderJsonValue(HttpServletResponse response, String name, Object value) {
+    private void setHeaderJsonValue(HttpServletResponse response, HtmxResponseHeader header, Object value) {
         try {
-            response.setHeader(name, objectMapper.writeValueAsString(value));
+            response.setHeader(header.getValue(), objectMapper.writeValueAsString(value));
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Unable to set header " + name + " to " + value, e);
+            throw new IllegalArgumentException("Unable to set header " + header.getValue() + " to " + value, e);
         }
     }
 
-    private void setHeader(HttpServletResponse response, String name, String[] values) {
-        response.setHeader(name, String.join(",", values));
+    private void setHeader(HttpServletResponse response, HtmxResponseHeader header, String value) {
+        response.setHeader(header.getValue(), value);
+    }
+
+    private void setHeader(HttpServletResponse response, HtmxResponseHeader header, String[] values) {
+        response.setHeader(header.getValue(), String.join(",", values));
     }
 
     private HtmxLocation convertToLocation(HxLocation annotation) {

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -30,6 +30,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxLocation(response, method);
+            setHxPushUrl(response, method);
             setHxRedirect(response, method);
             setHxReplaceUrl(response, method);
             setHxTrigger(response, method);
@@ -55,6 +56,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             } else {
                 response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
             }
+        }
+    }
+
+    private void setHxPushUrl(HttpServletResponse response, Method method) {
+        HxPushUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxPushUrl.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_PUSH_URL.getValue(), methodAnnotation.value());
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -35,6 +35,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             setHxRedirect(response, method);
             setHxReplaceUrl(response, method);
             setHxReswap(response, method);
+            setHxRetarget(response, method);
             setHxTrigger(response, method);
             setHxRefresh(response, method);
             setVary(request, response);
@@ -86,6 +87,13 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         HxReswap methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReswap.class);
         if (methodAnnotation != null) {
             response.setHeader(HX_RESWAP.getValue(), convertToReswap(methodAnnotation));
+        }
+    }
+
+    private void setHxRetarget(HttpServletResponse response, Method method) {
+        HxRetarget methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRetarget.class);
+        if (methodAnnotation != null) {
+            response.setHeader(HX_RETARGET.getValue(), methodAnnotation.value());
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
@@ -43,7 +43,7 @@ public class HtmxMvcAutoConfiguration implements WebMvcRegistrations, WebMvcConf
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new HtmxHandlerInterceptor());
+        registry.addInterceptor(new HtmxHandlerInterceptor(objectMapper));
     }
 
     @Override

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxValue.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxValue.java
@@ -1,0 +1,13 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+/**
+ * Holder for constant values.
+ */
+public class HtmxValue {
+
+    /**
+     * Constant for use in annotations that support a {@code false} value to disable functions.
+     */
+    public static final String FALSE = "false";
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxValue.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxValue.java
@@ -10,4 +10,9 @@ public class HtmxValue {
      */
     public static final String FALSE = "false";
 
+    /**
+     * Constant for use in annotations that support a {@code true} value to enable functions.
+     */
+    public static final String TRUE = "true";
+
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.java
@@ -1,0 +1,55 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Annotation to do a client side redirect that does not do a full page reload.
+ * <p>
+ * Note that this annotation does not provide support for specifying {@code values} or {@code headers}.
+ * If you want to do this, use {@link HtmxResponse} instead.
+ *
+ * @see <a href="https://htmx.org/headers/hx-location/">HX-Location Response Header</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxLocation {
+
+    /**
+     * The url path to make the redirect.
+     * <p>This is an alias for {@link #path}. For example,
+     * {@code @HxLocation("/foo")} is equivalent to
+     * {@code @HxLocation(path="/foo")}.
+     */
+    @AliasFor("path")
+    String value() default "";
+    /**
+     * The url path to make the redirect.
+     */
+    String path() default "";
+    /**
+     * The source element of the request
+     */
+    String source() default "";
+    /**
+     * An event that "triggered" the request
+     */
+    String event() default "";
+    /**
+     * A callback that will handle the response HTML.
+     */
+    String handler() default "";
+    /**
+     * The target to swap the response into.
+     */
+    String target() default "";
+    /**
+     * How the response will be swapped in relative to the target
+     */
+    String swap() default "";
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxPushUrl.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxPushUrl.java
@@ -1,0 +1,31 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to push a URL into the browser
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API">location history</a>.
+ * <p>
+ * The possible values are:
+ * <ul>
+ * <li>{@link HtmxValue#TRUE}, which pushes the fetched URL into history.</li>
+ * <li>{@link HtmxValue#FALSE}, which disables pushing the fetched URL if it would otherwise be pushed.</li>
+ * <li>A URL to be pushed into the location bar. This may be relative or absolute,
+ * as per <a href="https://developer.mozilla.org/en-US/docs/Web/API/History/pushState">history.pushState()</a>.</li>
+ * </ul>
+ *
+ * @see <a href="https://htmx.org/headers/hx-push-url/">HX-Push-Url Response Header</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxPushUrl {
+
+    /**
+     * The value for the {@code HX-Push-Url} response header.
+     */
+    String value() default HtmxValue.TRUE;
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.java
@@ -1,0 +1,22 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to do a client-side redirect to a new location.
+ *
+ * @see <a href="https://htmx.org/reference/#response_headers">HX-Redirect</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxRedirect {
+
+    /**
+     * The URL to use to do a client-side redirect to a new location.
+     */
+    String value();
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
@@ -1,0 +1,32 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to replace the current URL in the browser
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API">location history</a>.
+ * <p>
+ * The possible values are:
+ * <ul>
+ * <li>{@link HtmxValue#TRUE}, which replaces the current URL with the fetched URL in the history.</li>
+ * <li>{@link HtmxValue#FALSE}, which prevents the browser’s current URL from being updated.</li>
+ * <li>A URL to replace the current URL in the location bar. This may be relative or absolute, as per 
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState">history.replaceState()</a>,
+ * but must have the same origin as the current URL.</li>
+ * </ul>
+ *
+ * @see <a href="https://htmx.org/headers/hx-replace-url/">HX-Replace-Url</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxReplaceUrl {
+
+    /**
+     * The value for the {@code HX-Replace-Url} response header.
+     */
+    String value();
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReselect.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReselect.java
@@ -1,0 +1,24 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify a CSS selector that allows you to choose which part
+ * of the response is used to be swapped in.
+ *
+ * @see <a href="https://htmx.org/reference/#response_headers">HX-Retarget</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxReselect {
+
+    /**
+     * A CSS selector that allows you to choose which part of the response is used to be swapped in.
+     * <p>Overrides an existing <a href="https://htmx.org/attributes/hx-select/">hx-select</a> on the triggering element.
+     */
+    String value();
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
@@ -1,0 +1,85 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify how the response will be swapped.
+ * See <a href="https://htmx.org/attributes/hx-swap/">hx-swap</a> for possible values.
+ *
+ * @see <a href="https://htmx.org/reference/#response_headers">HX-Reswap</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxReswap {
+
+    /**
+     * A value to specify how the response will be swapped.
+     *
+     * @see <a href="https://htmx.org/attributes/hx-swap/">hx-swap</a>
+     */
+    HxSwapType value() default HxSwapType.INNER_HTML;
+
+    /**
+     * Set the time in milliseconds that should elapse after receiving a response to swap the content.
+     */
+    long swap() default -1;
+
+    /**
+     * Set the time in milliseconds that should elapse between the swap and the settle logic.
+     */
+    long settle() default -1;
+
+    /**
+     * Changes the scrolling behavior of the target element.
+     */
+    Position scroll() default Position.UNDEFINED;
+
+    /**
+     * Used to target a different element for scrolling.
+     */
+    String scrollTarget() default "";
+
+    /**
+     * Changes the scrolling behavior of the target element.
+     */
+    Position show() default Position.UNDEFINED;
+
+    /**
+     * Used to target a different element for showing.
+     */
+    String showTarget() default "";
+
+    /**
+     * Enables the use of the new
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API">View Transitions API</a>
+     * when a swap occurs.
+     */
+    boolean transition() default false;
+
+    /**
+     * Enable or disable auto-scrolling to focused inputs between requests.
+     */
+    FocusScroll focusScroll() default FocusScroll.UNDEFINED;
+
+    /**
+     * Represents the values for {@link #focusScroll()}
+     */
+    public enum FocusScroll {
+        TRUE,
+        FALSE,
+        UNDEFINED
+    }
+
+    /**
+     * Represents the position values for {@link #show()} and {@link #scroll()}
+     */
+    public enum Position {
+        TOP,
+        BOTTOM,
+        UNDEFINED
+    }
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRetarget.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRetarget.java
@@ -1,0 +1,23 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify a CSS selector that updates the target of
+ * the content update to a different element on the page.
+ *
+ * @see <a href="https://htmx.org/reference/#response_headers">HX-Retarget</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HxRetarget {
+
+    /**
+     * A CSS selector that updates the target of the content update to a different element on the page.
+     */
+    String value();
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSettle.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSettle.java
@@ -6,7 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to trigger client side events as soon as the response is received on the target element.
+ * Annotation to trigger client side events after the 
+ * <a href="https://htmx.org/docs/#request-operations">settling step</a>
+ * on the target element.
  * <br>
  * You can trigger a single event or as many uniquely named events as you would like.
  *
@@ -14,16 +16,13 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface HxTrigger {
+public @interface HxTriggerAfterSettle {
 
     /**
-     * The events to trigger as soon as the response is received on the target element.
+     * The events to trigger after the 
+     * <a href="https://htmx.org/docs/#request-operations">settling step</a>
+     * on the target element.
      */
     String[] value();
 
-    /**
-     * @deprecated use annotation {@link HxTriggerAfterSettle} or {@link HxTriggerAfterSwap} instead.
-     */
-    @Deprecated
-    HxTriggerLifecycle lifecycle() default HxTriggerLifecycle.RECEIVE;
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSwap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerAfterSwap.java
@@ -6,7 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to trigger client side events as soon as the response is received on the target element.
+ * Annotation to trigger client side events after the 
+ * <a href="https://htmx.org/docs/#request-operations">swap step</a>
+ * on the target element.
  * <br>
  * You can trigger a single event or as many uniquely named events as you would like.
  *
@@ -14,16 +16,13 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface HxTrigger {
+public @interface HxTriggerAfterSwap {
 
     /**
-     * The events to trigger as soon as the response is received on the target element.
+     * The events to trigger after the 
+     * <a href="https://htmx.org/docs/#request-operations">swap step</a>
+     * on the target element.
      */
     String[] value();
 
-    /**
-     * @deprecated use annotation {@link HxTriggerAfterSettle} or {@link HxTriggerAfterSwap} instead.
-     */
-    @Deprecated
-    HxTriggerLifecycle lifecycle() default HxTriggerLifecycle.RECEIVE;
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerLifecycle.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxTriggerLifecycle.java
@@ -4,7 +4,9 @@ package io.github.wimdeblauwe.htmx.spring.boot.mvc;
  * Represents the HX-Trigger Response Headers.
  *
  * @see <a href="https://htmx.org/headers/hx-trigger/">HX-Trigger Response Headers</a>
+ * @deprecated use annotation {@link HxTriggerAfterSettle} or {@link HxTriggerAfterSwap} instead.
  */
+@Deprecated
 public enum HxTriggerLifecycle {
     /**
      * Trigger events as soon as the response is received.

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -117,4 +117,11 @@ class HtmxHandlerInterceptorTest {
                .andExpect(header().string("HX-Replace-Url", "/path"));
     }
 
+    @Test
+    public void testHxReswap() throws Exception {
+        mockMvc.perform(get("/hx-reswap"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reswap", "innerHTML swap:300ms"));
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -97,6 +97,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxRedirect() throws Exception {
+        mockMvc.perform(get("/hx-redirect"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Redirect", "/path"));
+    }
+
+    @Test
     public void testHxReplaceUrl() throws Exception {
         mockMvc.perform(get("/hx-replace-url"))
                .andExpect(status().isOk())

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -81,4 +81,19 @@ class HtmxHandlerInterceptorTest {
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Refresh", "true"));
     }
+
+    @Test
+    public void testHxLocationWithContextData() throws Exception {
+        mockMvc.perform(get("/hx-location-with-context-data"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "{\"path\":\"/path\",\"source\":\"source\",\"event\":\"event\",\"handler\":\"handler\",\"target\":\"target\",\"swap\":\"swap\"}"));
+    }
+
+    @Test
+    public void testHxLocationWithoutContextData() throws Exception {
+        mockMvc.perform(get("/hx-location-without-context-data"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "/path"));
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -27,6 +27,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHeaderIsSetOnResponseWithMultipleEventsIfHxTriggerIsPresent() throws Exception {
+        mockMvc.perform(get("/with-trigger-multiple-events"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger", "event1,event2"));
+    }
+
+    @Test
     public void testAfterSettleHeaderIsSetOnResponseIfHxTriggerIsPresent() throws Exception {
         mockMvc.perform(get("/with-trigger-settle"))
                .andExpect(status().isOk())
@@ -38,6 +45,43 @@ class HtmxHandlerInterceptorTest {
         mockMvc.perform(get("/with-trigger-swap"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Trigger-After-Swap", "eventTriggered"));
+    }
+
+    @Test
+    public void testAfterSettleHeaderIsSetOnResponseIfHxTriggerAfterSettleIsPresent() throws Exception {
+        mockMvc.perform(get("/with-trigger-after-settle"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger-After-Settle", "eventTriggered"));
+    }
+
+    @Test
+    public void testAfterSettleHeaderIsSetOnResponseWithMultipleEventsIfHxTriggerAfterSettleIsPresent() throws Exception {
+        mockMvc.perform(get("/with-trigger-after-settle-multiple-events"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger-After-Settle", "event1,event2"));
+    }
+
+    @Test
+    public void testAfterSwapHeaderIsSetOnResponseIfHxTriggerAfterSwapIsPresent() throws Exception {
+        mockMvc.perform(get("/with-trigger-after-swap"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger-After-Swap", "eventTriggered"));
+    }
+
+    @Test
+    public void testAfterSwapHeaderIsSetOnResponseWithMultipleEventsIfHxTriggerAfterSwapIsPresent() throws Exception {
+        mockMvc.perform(get("/with-trigger-after-swap-multiple-events"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger-After-Swap", "event1,event2"));
+    }
+
+    @Test
+    public void testHeadersAreSetOnResponseIfHxTriggersArePresent() throws Exception {
+        mockMvc.perform(get("/with-triggers"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger", "event1,event2"))
+               .andExpect(header().string("HX-Trigger-After-Settle", "event1,event2"))
+               .andExpect(header().string("HX-Trigger-After-Swap", "event1,event2"));
     }
 
     @Test

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -97,6 +97,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxPushUrl() throws Exception {
+        mockMvc.perform(get("/hx-push-url"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "/path"));
+    }
+
+    @Test
     public void testHxRedirect() throws Exception {
         mockMvc.perform(get("/hx-redirect"))
                .andExpect(status().isOk())

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -124,4 +124,11 @@ class HtmxHandlerInterceptorTest {
                .andExpect(header().string("HX-Reswap", "innerHTML swap:300ms"));
     }
 
+    @Test
+    public void testHxRetarget() throws Exception {
+        mockMvc.perform(get("/hx-retarget"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Retarget", "#target"));
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -131,4 +131,11 @@ class HtmxHandlerInterceptorTest {
                .andExpect(header().string("HX-Retarget", "#target"));
     }
 
+    @Test
+    public void testHxReselect() throws Exception {
+        mockMvc.perform(get("/hx-reselect"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reselect", "#target"));
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -96,4 +96,11 @@ class HtmxHandlerInterceptorTest {
                .andExpect(header().string("HX-Location", "/path"));
     }
 
+    @Test
+    public void testHxReplaceUrl() throws Exception {
+        mockMvc.perform(get("/hx-replace-url"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", "/path"));
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -77,6 +77,13 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-push-url")
+    @HxPushUrl("/path")
+    @ResponseBody
+    public String hxPushUrl() {
+        return "";
+    }
+
     @GetMapping("/hx-redirect")
     @HxRedirect("/path")
     @ResponseBody

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -98,4 +98,11 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-reswap")
+    @HxReswap(value = HxSwapType.INNER_HTML, swap = 300)
+    @ResponseBody
+    public String hxReswap() {
+        return "";
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -77,4 +77,11 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-replace-url")
+    @HxReplaceUrl("/path")
+    @ResponseBody
+    public String hxReplaceUrl() {
+        return "";
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -112,4 +112,11 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-reselect")
+    @HxReselect("#target")
+    @ResponseBody
+    public String hxReselect() {
+        return "";
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -50,7 +50,6 @@ public class TestController {
         return "";
     }
 
-
     @GetMapping("/hx-refresh")
     @HxRefresh
     @ResponseBody
@@ -61,6 +60,20 @@ public class TestController {
     @GetMapping("/hx-vary")
     @ResponseBody
     public String hxVary() {
+        return "";
+    }
+
+    @GetMapping("/hx-location-without-context-data")
+    @HxLocation("/path")
+    @ResponseBody
+    public String hxLocationWithoutContextData() {
+        return "";
+    }
+
+    @GetMapping("/hx-location-with-context-data")
+    @HxLocation(path = "/path", source = "source", event = "event", handler = "handler", target = "target", swap = "swap")
+    @ResponseBody
+    public String hxLocationWithContextData() {
         return "";
     }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -105,4 +105,11 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-retarget")
+    @HxRetarget("#target")
+    @ResponseBody
+    public String hxRetarget() {
+        return "";
+    }
+
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -77,6 +77,13 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-redirect")
+    @HxRedirect("/path")
+    @ResponseBody
+    public String hxRedirect() {
+        return "";
+    }
+
     @GetMapping("/hx-replace-url")
     @HxReplaceUrl("/path")
     @ResponseBody

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -22,17 +22,61 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/with-trigger-multiple-events")
+    @HxTrigger({ "event1", "event2" })
+    @ResponseBody
+    public String methodWithHxTriggerAndMultipleEvents() {
+        return "";
+    }
+
     @GetMapping("/with-trigger-settle")
     @HxTrigger(value = "eventTriggered", lifecycle = HxTriggerLifecycle.SETTLE)
     @ResponseBody
-    public String methodWithHxTriggerAfterSettle() {
+    public String methodWithHxTriggerAndLifecycleSettle() {
         return "";
     }
 
     @GetMapping("/with-trigger-swap")
     @HxTrigger(value = "eventTriggered", lifecycle = HxTriggerLifecycle.SWAP)
     @ResponseBody
+    public String methodWithHxTriggerAndLifecycleSwap() {
+        return "";
+    }
+
+    @GetMapping("/with-trigger-after-settle")
+    @HxTriggerAfterSettle("eventTriggered")
+    @ResponseBody
+    public String methodWithHxTriggerAfterSettle() {
+        return "";
+    }
+
+    @GetMapping("/with-trigger-after-settle-multiple-events")
+    @HxTriggerAfterSettle({ "event1", "event2" })
+    @ResponseBody
+    public String methodWithHxTriggerAfterSettleAndMultipleEvents() {
+        return "";
+    }
+
+    @GetMapping("/with-trigger-after-swap")
+    @HxTriggerAfterSwap("eventTriggered")
+    @ResponseBody
     public String methodWithHxTriggerAfterSwap() {
+        return "";
+    }
+
+    @GetMapping("/with-trigger-after-swap-multiple-events")
+    @HxTriggerAfterSwap({ "event1", "event2" })
+    @ResponseBody
+    public String methodWithHxTriggerAfterSwapAndMultipleEvents() {
+        return "";
+    }
+
+    @GetMapping("/with-triggers")
+    @HxTrigger({ "event1", "event2" })
+    @HxTriggerAfterSettle({ "event1", "event2" })
+    @HxTriggerAfterSwap({ "event1", "event2" })
+    @ResponseBody
+    public String methodWithHxTriggers() {
         return "";
     }
 


### PR DESCRIPTION
This will add the missing annotations for all available response headers.

Superseded #117.