### PR TITLE
[fix] Invalid characters (CR/LF) in response header caused by customized Jackson ObjectMapper

### DIFF
--- a/htmx-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/thymeleaf/HtmxThymeleafAutoConfiguration.java
+++ b/htmx-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/thymeleaf/HtmxThymeleafAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.wimdeblauwe.htmx.spring.boot.thymeleaf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
@@ -8,8 +9,10 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration
 @ConditionalOnWebApplication
 public class HtmxThymeleafAutoConfiguration {
+
     @Bean
-    public HtmxDialect htmxDialect(ObjectMapper mapper) {
-        return new HtmxDialect(mapper);
+    public HtmxDialect htmxDialect() {
+        return new HtmxDialect(JsonMapper.builder().build());
     }
+
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -26,14 +27,13 @@ public class HtmxMvcAutoConfiguration implements WebMvcRegistrations, WebMvcConf
     private final ObjectMapper objectMapper;
 
     HtmxMvcAutoConfiguration(@Qualifier("viewResolver") ObjectFactory<ViewResolver> resolver,
-                             ObjectFactory<LocaleResolver> locales,
-                             ObjectMapper objectMapper) {
+                             ObjectFactory<LocaleResolver> locales) {
         Assert.notNull(resolver, "ViewResolver must not be null!");
         Assert.notNull(locales, "LocaleResolver must not be null!");
 
         this.resolver = resolver;
         this.locales = locales;
-        this.objectMapper = objectMapper;
+        this.objectMapper = JsonMapper.builder().build();
     }
 
     @Override


### PR DESCRIPTION
Due to the fact that a user can customize the Jackson ObjectMapper bean (e.g. `spring.jackson.serialization.indent-output=true`) in Spring Boot, this leads to unwanted errors when it comes to serializing. Therefore, we no longer rely on this ObjectMapper.

Fixes #57