### PR TITLE
Add support for processing HtmxResponse in the Model and as an Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ public String endpoint(HtmxResponse.Builder htmxResponse, Model model) {
 }
 ```
 
-For example the JTE templating library supports statically typed templates and can be used like so:
+For example the [JTE templating library](https://jte.gg/) supports statically typed templates and can be used like so:
 
 ```java
 @GetMapping("/endpoint")

--- a/README.md
+++ b/README.md
@@ -181,6 +181,35 @@ public HtmxResponse getMainAndPartial(Model model){
 
 Using `ModelAndView` means that each fragment can have its own model (which is merged with the controller model before rendering).
 
+### HtmxResponse.Builder as an argument
+
+An `HtmxReponse.Builder` can be injected as a controller method. This creates the parameter and adds it to the model, 
+allowing it to be used without requiring it be the method return value. This is useful when the return value is needed for
+the template.
+
+This allows for the following usage:
+
+```java
+@GetMapping("/endpoint")
+public String endpoint(HtmxResponse.Builder htmxResponse, Model model) {
+    htmxResponse.trigger("event1");
+    model.addAttribute("aField", "aValue");
+    return "endpointTemplate";
+}
+```
+
+For example the JTE templating library supports statically typed templates and can be used like so:
+
+```java
+@GetMapping("/endpoint")
+public JteModel endpoint(HtmxResponse.Builder htmxResponse) {
+    htmxResponse.trigger("event1");
+    String aField = "aValue";
+    return templates.endpointTemplate(aField);
+}
+```
+
+
 ### Error handlers
 
 It is possible to use `HtmxResponse` as a return type from error handlers.

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
@@ -43,16 +43,21 @@ public class HtmxMvcAutoConfiguration implements WebMvcRegistrations, WebMvcConf
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new HtmxHandlerInterceptor(objectMapper));
+        registry.addInterceptor(new HtmxHandlerInterceptor(objectMapper, createHtmxReponseHandler()));
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new HtmxHandlerMethodArgumentResolver());
+        resolvers.add(new HtmxResponseHandlerMethodArgumentResolver());
     }
 
     @Override
     public void addReturnValueHandlers(List<HandlerMethodReturnValueHandler> handlers) {
-        handlers.add(new HtmxResponseHandlerMethodReturnValueHandler(resolver.getObject(), locales, objectMapper));
+        handlers.add(createHtmxReponseHandler());
+    }
+
+    private HtmxResponseHandlerMethodReturnValueHandler createHtmxReponseHandler() {
+        return new HtmxResponseHandlerMethodReturnValueHandler(resolver.getObject(), locales, objectMapper);
     }
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolver.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolver.java
@@ -1,0 +1,26 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class HtmxResponseHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(HtmxResponse.Builder.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HtmxResponse.Builder htmxResponseBuilder = HtmxResponse.builder();
+        if(mavContainer != null) {
+            mavContainer.addAttribute(htmxResponseBuilder);
+        }
+        return htmxResponseBuilder;
+    }
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandler.java
@@ -50,7 +50,7 @@ public class HtmxResponseHandlerMethodReturnValueHandler implements HandlerMetho
         addHxHeaders(htmxResponse, webRequest.getNativeResponse(HttpServletResponse.class));
     }
 
-    private View toView(HtmxResponse htmxResponse) {
+    View toView(HtmxResponse htmxResponse) {
 
         Assert.notNull(htmxResponse, "HtmxResponse must not be null!");
 
@@ -74,7 +74,7 @@ public class HtmxResponseHandlerMethodReturnValueHandler implements HandlerMetho
         };
     }
 
-    private void addHxHeaders(HtmxResponse htmxResponse, HttpServletResponse response) {
+    void addHxHeaders(HtmxResponse htmxResponse, HttpServletResponse response) {
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER, htmxResponse.getTriggersInternal());
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SETTLE, htmxResponse.getTriggersAfterSettleInternal());
         addHxTriggerHeaders(response, HtmxResponseHeader.HX_TRIGGER_AFTER_SWAP, htmxResponse.getTriggersAfterSwapInternal());

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerController.java
@@ -137,6 +137,14 @@ public class HtmxResponseHandlerMethodReturnValueHandlerController {
         throw new RuntimeException("Fake exception");
     }
 
+    @GetMapping("/argument")
+    public String argument(HtmxResponse.Builder htmxResponse) {
+        htmxResponse.trigger("event1");
+        return "argument";
+    }
+
+
+
     @ExceptionHandler(Exception.class)
     public HtmxResponse handleError(Exception ex) {
         return HtmxResponse.builder()

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
@@ -143,4 +143,11 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
                                               <span>Fake exception</span>
                                           </span>""");
     }
+
+    @Test
+    public void testHxTriggerArgument() throws Exception {
+        mockMvc.perform(get("/hvhi/argument"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Trigger", "event1"));
+    }
 }


### PR DESCRIPTION
Addresses #127 

This enables the following usecase:

```kotlin
@GetMapping("/admin")
fun getAdmin(htmxResponse: HtmxResponse.Builder): JteModel {
    htmxResponse.trigger("aTrigger")
    return templates.adminIndex("Hello")
}
```

The `JteModel` is a typed template. But the `HtmxResponse` can be used as an argument to inform any triggers, redirect, etc. that need to happen. 

This change also supports adding `HtmxReponse` to the model and being processed, if that approach is needed.