### PR TITLE
@HxPushUrl(true) now retreives the path from the request

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -5,6 +5,8 @@ import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.*;
 import java.lang.reflect.Method;
 import java.time.Duration;
 
+import java.util.Objects;
+
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.HandlerMethod;
@@ -60,7 +62,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxLocation(response, method);
-            setHxPushUrl(response, method);
+            setHxPushUrl(request, response, method);
             setHxRedirect(response, method);
             setHxReplaceUrl(response, method);
             setHxReswap(response, method);
@@ -94,10 +96,19 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         }
     }
 
-    private void setHxPushUrl(HttpServletResponse response, Method method) {
+    private void setHxPushUrl(HttpServletRequest request, HttpServletResponse response, Method method) {
         HxPushUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxPushUrl.class);
         if (methodAnnotation != null) {
-            setHeader(response, HX_PUSH_URL, methodAnnotation.value());
+            if(!Objects.equals(methodAnnotation.value(), HtmxValue.TRUE)){
+                setHeader(response, HX_PUSH_URL, methodAnnotation.value());
+            }
+            String path = request.getRequestURI();
+            String queryString = request.getQueryString();
+
+            if (queryString != null && !queryString.isEmpty()) {
+                path += "?" + queryString;
+            }
+            setHeader(response, HX_PUSH_URL, path);
         }
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -1,24 +1,21 @@
 package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 
-import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.*;
-
-import java.lang.reflect.Method;
-import java.time.Duration;
-
-import java.util.Objects;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.*;
 
 public class HtmxHandlerInterceptor implements HandlerInterceptor {
 
@@ -32,10 +29,10 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
 
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
-        if(modelAndView != null) {
+        if (modelAndView != null) {
             modelAndView.getModel().values().forEach(
-                    value ->{
-                        if(value instanceof HtmxResponse) {
+                    value -> {
+                        if (value instanceof HtmxResponse) {
                             buildAndRender((HtmxResponse) value, modelAndView, request, response);
                         } else if (value instanceof HtmxResponse.Builder) {
                             buildAndRender(((HtmxResponse.Builder) value).build(), modelAndView, request, response);
@@ -64,7 +61,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             setHxLocation(response, method);
             setHxPushUrl(request, response, method);
             setHxRedirect(response, method);
-            setHxReplaceUrl(response, method);
+            setHxReplaceUrl(request, response, method);
             setHxReswap(response, method);
             setHxRetarget(response, method);
             setHxReselect(response, method);
@@ -99,16 +96,11 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
     private void setHxPushUrl(HttpServletRequest request, HttpServletResponse response, Method method) {
         HxPushUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxPushUrl.class);
         if (methodAnnotation != null) {
-            if(!Objects.equals(methodAnnotation.value(), HtmxValue.TRUE)){
+            if (HtmxValue.TRUE.equals(methodAnnotation.value())) {
+                setHeader(response, HX_PUSH_URL, getRequestUrl(request));
+            } else {
                 setHeader(response, HX_PUSH_URL, methodAnnotation.value());
             }
-            String path = request.getRequestURI();
-            String queryString = request.getQueryString();
-
-            if (queryString != null && !queryString.isEmpty()) {
-                path += "?" + queryString;
-            }
-            setHeader(response, HX_PUSH_URL, path);
         }
     }
 
@@ -119,10 +111,14 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         }
     }
 
-    private void setHxReplaceUrl(HttpServletResponse response, Method method) {
+    private void setHxReplaceUrl(HttpServletRequest request, HttpServletResponse response, Method method) {
         HxReplaceUrl methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxReplaceUrl.class);
         if (methodAnnotation != null) {
-            setHeader(response, HX_REPLACE_URL, methodAnnotation.value());
+            if (HtmxValue.TRUE.equals(methodAnnotation.value())) {
+                setHeader(response, HX_REPLACE_URL, getRequestUrl(request));
+            } else {
+                setHeader(response, HX_REPLACE_URL, methodAnnotation.value());
+            }
         }
     }
 
@@ -263,5 +259,16 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             default -> throw new IllegalStateException("Unexpected value: " + position);
         };
     }
+
+    private String getRequestUrl(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String queryString = request.getQueryString();
+
+        if (queryString != null && !queryString.isEmpty()) {
+            path += "?" + queryString;
+        }
+        return path;
+    }
+
 
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
@@ -27,6 +27,6 @@ public @interface HxReplaceUrl {
     /**
      * The value for the {@code HX-Replace-Url} response header.
      */
-    String value();
+    String value() default HtmxValue.TRUE;
 
 }

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -154,6 +154,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxPushUrlFalse() throws Exception {
+        mockMvc.perform(get("/hx-push-url-false?test=hello"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "false"));
+    }
+
+    @Test
     public void testHxRedirect() throws Exception {
         mockMvc.perform(get("/hx-redirect"))
                .andExpect(status().isOk())
@@ -161,10 +168,24 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
-    public void testHxReplaceUrl() throws Exception {
-        mockMvc.perform(get("/hx-replace-url"))
+    public void testHxReplaceUrlPath() throws Exception {
+        mockMvc.perform(get("/hx-replace-url-path"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Replace-Url", "/path"));
+    }
+
+    @Test
+    public void testHxReplaceUrl() throws Exception {
+        mockMvc.perform(get("/hx-replace-url?test=hello&test2=hello2"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", "/hx-replace-url?test=hello&test2=hello2"));
+    }
+
+    @Test
+    public void testHxReplaceUrlFalse() throws Exception {
+        mockMvc.perform(get("/hx-replace-url-false?test=hello"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", "false"));
     }
 
     @Test

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -141,10 +141,16 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
-    public void testHxPushUrl() throws Exception {
-        mockMvc.perform(get("/hx-push-url"))
+    public void testHxPushUrlPath() throws Exception {
+        mockMvc.perform(get("/hx-push-url-path"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Push-Url", "/path"));
+    }
+    @Test
+    public void testHxPushUrl() throws Exception {
+        mockMvc.perform(get("/hx-push-url?test=hello"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "/hx-push-url?test=hello"));
     }
 
     @Test

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -121,8 +121,15 @@ public class TestController {
         return "";
     }
 
-    @GetMapping("/hx-push-url")
+    @GetMapping("/hx-push-url-path")
     @HxPushUrl("/path")
+    @ResponseBody
+    public String hxPushUrlPath() {
+        return "";
+    }
+
+    @GetMapping("/hx-push-url")
+    @HxPushUrl
     @ResponseBody
     public String hxPushUrl() {
         return "";

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/TestController.java
@@ -135,6 +135,13 @@ public class TestController {
         return "";
     }
 
+    @GetMapping("/hx-push-url-false")
+    @HxPushUrl(HtmxValue.FALSE)
+    @ResponseBody
+    public String hxPushUrlFalse() {
+        return "";
+    }
+
     @GetMapping("/hx-redirect")
     @HxRedirect("/path")
     @ResponseBody
@@ -142,10 +149,22 @@ public class TestController {
         return "";
     }
 
-    @GetMapping("/hx-replace-url")
+    @GetMapping("/hx-replace-url-path")
     @HxReplaceUrl("/path")
     @ResponseBody
+    public String hxReplaceUrlPath() {
+        return "";
+    }
+    @GetMapping("/hx-replace-url")
+    @HxReplaceUrl
+    @ResponseBody
     public String hxReplaceUrl() {
+        return "";
+    }
+    @GetMapping("/hx-replace-url-false")
+    @HxReplaceUrl(HtmxValue.FALSE)
+    @ResponseBody
+    public String hxReplaceUrlFalse() {
         return "";
     }
 


### PR DESCRIPTION
When using `@HxPushUrl` without a value it pushes `true` in the url, instead of the fetched URL

<img width="796" alt="image" src="https://github.com/user-attachments/assets/fb3ac8b4-6116-402e-9bb7-64335dbf0738">

Now the path gets retreived from the request.