### PR TITLE
Prepend context path to context relative URLs in htmx response headers

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptor.java
@@ -57,9 +57,9 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
 
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
-            setHxLocation(response, method);
+            setHxLocation(request, response, method);
             setHxPushUrl(request, response, method);
-            setHxRedirect(response, method);
+            setHxRedirect(request, response, method);
             setHxReplaceUrl(request, response, method);
             setHxReswap(response, method);
             setHxRetarget(response, method);
@@ -80,14 +80,15 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
         }
     }
 
-    private void setHxLocation(HttpServletResponse response, Method method) {
+    private void setHxLocation(HttpServletRequest request, HttpServletResponse response, Method method) {
         HxLocation methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxLocation.class);
         if (methodAnnotation != null) {
             var location = convertToLocation(methodAnnotation);
             if (location.hasContextData()) {
+                location.setPath(RequestContextUtils.createUrl(request, location.getPath(), methodAnnotation.contextRelative()));
                 setHeaderJsonValue(response, HtmxResponseHeader.HX_LOCATION, location);
             } else {
-                setHeader(response, HtmxResponseHeader.HX_LOCATION, location.getPath());
+                setHeader(response, HtmxResponseHeader.HX_LOCATION, RequestContextUtils.createUrl(request, location.getPath(), methodAnnotation.contextRelative()));
             }
         }
     }
@@ -98,15 +99,15 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             if (HtmxValue.TRUE.equals(methodAnnotation.value())) {
                 setHeader(response, HX_PUSH_URL, getRequestUrl(request));
             } else {
-                setHeader(response, HX_PUSH_URL, methodAnnotation.value());
+                setHeader(response, HX_PUSH_URL, RequestContextUtils.createUrl(request, methodAnnotation.value(), methodAnnotation.contextRelative()));
             }
         }
     }
 
-    private void setHxRedirect(HttpServletResponse response, Method method) {
+    private void setHxRedirect(HttpServletRequest request, HttpServletResponse response, Method method) {
         HxRedirect methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, HxRedirect.class);
         if (methodAnnotation != null) {
-            setHeader(response, HX_REDIRECT, methodAnnotation.value());
+            setHeader(response, HX_REDIRECT, RequestContextUtils.createUrl(request, methodAnnotation.value(), methodAnnotation.contextRelative()));
         }
     }
 
@@ -116,7 +117,7 @@ public class HtmxHandlerInterceptor implements HandlerInterceptor {
             if (HtmxValue.TRUE.equals(methodAnnotation.value())) {
                 setHeader(response, HX_REPLACE_URL, getRequestUrl(request));
             } else {
-                setHeader(response, HX_REPLACE_URL, methodAnnotation.value());
+                setHeader(response, HX_REPLACE_URL, RequestContextUtils.createUrl(request, methodAnnotation.value(), methodAnnotation.contextRelative()));
             }
         }
     }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandler.java
@@ -18,7 +18,6 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.servlet.support.RequestContextUtils;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.util.Collection;
@@ -95,22 +94,23 @@ public class HtmxResponseHandlerMethodReturnValueHandler implements HandlerMetho
                 saveFlashAttributes(mavContainer, request, response, location.getPath());
             }
             if (location.hasContextData()) {
+                location.setPath(RequestContextUtils.createUrl(request, location.getPath(), htmxResponse.isContextRelative()));
                 setHeaderJsonValue(response, HtmxResponseHeader.HX_LOCATION.getValue(), location);
             } else {
-                response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), location.getPath());
+                response.setHeader(HtmxResponseHeader.HX_LOCATION.getValue(), RequestContextUtils.createUrl(request, location.getPath(), htmxResponse.isContextRelative()));
             }
         }
         if (htmxResponse.getReplaceUrl() != null) {
-            response.setHeader(HtmxResponseHeader.HX_REPLACE_URL.getValue(), htmxResponse.getReplaceUrl());
+            response.setHeader(HtmxResponseHeader.HX_REPLACE_URL.getValue(), RequestContextUtils.createUrl(request, htmxResponse.getReplaceUrl(), htmxResponse.isContextRelative()));
         }
         if (htmxResponse.getPushUrl() != null) {
-            response.setHeader(HtmxResponseHeader.HX_PUSH_URL.getValue(), htmxResponse.getPushUrl());
+            response.setHeader(HtmxResponseHeader.HX_PUSH_URL.getValue(), RequestContextUtils.createUrl(request, htmxResponse.getPushUrl(), htmxResponse.isContextRelative()));
         }
         if (htmxResponse.getRedirect() != null) {
             if (mavContainer != null) {
                 saveFlashAttributes(mavContainer, request, response, htmxResponse.getRedirect());
             }
-            response.setHeader(HtmxResponseHeader.HX_REDIRECT.getValue(), htmxResponse.getRedirect());
+            response.setHeader(HtmxResponseHeader.HX_REDIRECT.getValue(), RequestContextUtils.createUrl(request, htmxResponse.getRedirect(), htmxResponse.isContextRelative()));
         }
         if (htmxResponse.isRefresh()) {
             response.setHeader(HtmxResponseHeader.HX_REFRESH.getValue(), "true");
@@ -165,9 +165,9 @@ public class HtmxResponseHandlerMethodReturnValueHandler implements HandlerMetho
             Map<String, ?> flashAttributes = redirectAttributes.getFlashAttributes();
             if (!CollectionUtils.isEmpty(flashAttributes)) {
                 if (request != null) {
-                    RequestContextUtils.getOutputFlashMap(request).putAll(flashAttributes);
+                    org.springframework.web.servlet.support.RequestContextUtils.getOutputFlashMap(request).putAll(flashAttributes);
                     if (response != null) {
-                        RequestContextUtils.saveOutputFlashMap(location, request, response);
+                        org.springframework.web.servlet.support.RequestContextUtils.saveOutputFlashMap(location, request, response);
                     }
                 }
             }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxLocation.java
@@ -51,5 +51,9 @@ public @interface HxLocation {
      * How the response will be swapped in relative to the target
      */
     String swap() default "";
+    /**
+     * If the path should be interpreted as context relative if it starts with a slash ("/").
+     */
+    boolean contextRelative() default true;
 
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxPushUrl.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxPushUrl.java
@@ -27,5 +27,9 @@ public @interface HxPushUrl {
      * The value for the {@code HX-Push-Url} response header.
      */
     String value() default HtmxValue.TRUE;
+    /**
+     * If the URL should be interpreted as context relative if it starts with a slash ("/").
+     */
+    boolean contextRelative() default true;
 
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRedirect.java
@@ -18,5 +18,9 @@ public @interface HxRedirect {
      * The URL to use to do a client-side redirect to a new location.
      */
     String value();
+    /**
+     * If the URL should be interpreted as context relative if it starts with a slash ("/").
+     */
+    boolean contextRelative() default true;
 
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReplaceUrl.java
@@ -28,5 +28,9 @@ public @interface HxReplaceUrl {
      * The value for the {@code HX-Replace-Url} response header.
      */
     String value() default HtmxValue.TRUE;
+    /**
+     * If the URL should be interpreted as context relative if it starts with a slash ("/").
+     */
+    boolean contextRelative() default true;
 
 }

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/RequestContextUtils.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/RequestContextUtils.java
@@ -1,0 +1,34 @@
+package io.github.wimdeblauwe.htmx.spring.boot.mvc;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+final class RequestContextUtils {
+
+    /**
+     * Creates a URL by prepending the context path if {@code contextRelative}
+     * is {@code true} and the URL starts with a slash ("/").
+     *
+     * @param request         the request to use to obtain the context path
+     * @param url             the URL
+     * @param contextRelative whether to prepend the context path
+     * @return the target URL
+     */
+    static String createUrl(HttpServletRequest request, String url, boolean contextRelative) {
+        if (contextRelative && url.startsWith("/")) {
+            return getContextPath(request) + url;
+        }
+        return url;
+    }
+
+    private static String getContextPath(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        while (contextPath.startsWith("//")) {
+            contextPath = contextPath.substring(1);
+        }
+        return contextPath;
+    }
+
+    private RequestContextUtils() {
+    }
+
+}

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -134,10 +134,24 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
-    public void testHxLocationWithoutContextData() throws Exception {
-        mockMvc.perform(get("/hx-location-without-context-data"))
+    public void testHxLocationWithContextDataPathShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hx-location-with-context-data").contextPath("/test"))
                .andExpect(status().isOk())
-               .andExpect(header().string("HX-Location", "/path"));
+               .andExpect(header().string("HX-Location", "{\"path\":\"/test/path\",\"source\":\"source\",\"event\":\"event\",\"handler\":\"handler\",\"target\":\"target\",\"swap\":\"swap\"}"));
+    }
+
+    @Test
+    public void testHxLocationWithoutContextData() throws Exception {
+        mockMvc.perform(get("/test/hx-location-without-context-data").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "/test/path"));
+    }
+
+    @Test
+    public void testHxLocationWithoutContextDataShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hx-location-without-context-data").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "/test/path"));
     }
 
     @Test
@@ -146,6 +160,7 @@ class HtmxHandlerInterceptorTest {
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Push-Url", "/path"));
     }
+
     @Test
     public void testHxPushUrl() throws Exception {
         mockMvc.perform(get("/hx-push-url?test=hello"))
@@ -161,10 +176,24 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxPushUrlShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hx-push-url-path").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "/test/path"));
+    }
+
+    @Test
     public void testHxRedirect() throws Exception {
         mockMvc.perform(get("/hx-redirect"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Redirect", "/path"));
+    }
+
+    @Test
+    public void testHxRedirectShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hx-redirect").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Redirect", "/test/path"));
     }
 
     @Test
@@ -186,6 +215,13 @@ class HtmxHandlerInterceptorTest {
         mockMvc.perform(get("/hx-replace-url-false?test=hello"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Replace-Url", "false"));
+    }
+
+    @Test
+    public void testHxReplaceUrlShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hx-replace-url-path").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", "/test/path"));
     }
 
     @Test

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
@@ -26,10 +26,24 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
     }
 
     @Test
+    public void testHxLocationWithContextDataPathShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hvhi/hx-location-with-context-data").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "{\"path\":\"/test/path\",\"source\":\"source\",\"event\":\"event\",\"handler\":\"handler\",\"target\":\"target\",\"swap\":\"swap\",\"values\":{\"value1\":\"v1\",\"value2\":\"v2\"},\"headers\":{\"header1\":\"v1\",\"header2\":\"v2\"}}"));
+    }
+
+    @Test
     public void testHxLocationWithoutContextData() throws Exception {
         mockMvc.perform(get("/hvhi/hx-location-without-context-data"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Location", "/path"));
+    }
+
+    @Test
+    public void testHxLocationWithoutContextDataShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hvhi/hx-location-without-context-data").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "/test/path"));
     }
 
     @Test
@@ -48,10 +62,24 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
     }
 
     @Test
+    public void testHxPushUrlShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hvhi/hx-push-url").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Push-Url", "/test/path"));
+    }
+
+    @Test
     public void testHxRedirect() throws Exception {
         mockMvc.perform(get("/hvhi/hx-redirect"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Redirect", "/path"));
+    }
+
+    @Test
+    public void testHxRedirectShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hvhi/hx-redirect").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Redirect", "/test/path"));
     }
 
     @Test
@@ -74,6 +102,13 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
         mockMvc.perform(get("/hvhi/hx-replace-url"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Replace-Url", "/path"));
+    }
+
+    @Test
+    public void testHxReplaceUrlShouldPrependContextPath() throws Exception {
+        mockMvc.perform(get("/test/hvhi/hx-replace-url").contextPath("/test"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Replace-Url", "/test/path"));
     }
 
     @Test


### PR DESCRIPTION
I have noticed that URLs that can be set in htmx response headers e.g. `HX-Redirect` are not automatically interpreted as context relative. This is a bit annoying because you have to manually prepend the context path in your controller method. And that's why I've changed this behavior. Each URL starts with a slash ("/") is interpreted as context relative to the current ServletContext and therefore the context path will be prepended to the URL.

It is also possible to deactivate this behavior in the `HtmxResponse.Builder` and in all relevant annotations e.g `@HxRedirect` etc.