### PR TITLE
Handle flash attributes on htmx redirects

### DIFF
--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerController.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.time.Duration;
 import java.util.Map;
@@ -34,6 +35,12 @@ public class HtmxResponseHandlerMethodReturnValueHandlerController {
         return HtmxResponse.builder().location("/path").build();
     }
 
+    @GetMapping("/hx-location-with-flash-attributes")
+    public HtmxResponse hxLocationWithoutContextData(RedirectAttributes redirectAttributes) {
+        redirectAttributes.addFlashAttribute("flash", "test");
+        return HtmxResponse.builder().location("/path").build();
+    }
+
     @GetMapping("/hx-push-url")
     public HtmxResponse hxPushUrl() {
         return HtmxResponse.builder().pushUrl("/path").build();
@@ -41,6 +48,12 @@ public class HtmxResponseHandlerMethodReturnValueHandlerController {
 
     @GetMapping("/hx-redirect")
     public HtmxResponse hxRedirect() {
+        return HtmxResponse.builder().redirect("/path").build();
+    }
+
+    @GetMapping("/hx-redirect-with-flash-attributes")
+    public HtmxResponse hxRedirectWithFlashAttributes(RedirectAttributes redirectAttributes) {
+        redirectAttributes.addFlashAttribute("flash", "test");
         return HtmxResponse.builder().redirect("/path").build();
     }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodReturnValueHandlerTest.java
@@ -9,8 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(HtmxResponseHandlerMethodReturnValueHandlerController.class)
 @WithMockUser
@@ -34,6 +33,14 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
     }
 
     @Test
+    public void testHxLocationWithFlashAttributes() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-location-with-flash-attributes"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Location", "/path"))
+               .andExpect(flash().attribute("flash", "test"));
+    }
+
+    @Test
     public void testHxPushUrl() throws Exception {
         mockMvc.perform(get("/hvhi/hx-push-url"))
                .andExpect(status().isOk())
@@ -45,6 +52,14 @@ public class HtmxResponseHandlerMethodReturnValueHandlerTest {
         mockMvc.perform(get("/hvhi/hx-redirect"))
                .andExpect(status().isOk())
                .andExpect(header().string("HX-Redirect", "/path"));
+    }
+
+    @Test
+    public void testHxRedirectWithFlashAttributes() throws Exception {
+        mockMvc.perform(get("/hvhi/hx-redirect-with-flash-attributes"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Redirect", "/path"))
+               .andExpect(flash().attribute("flash", "test"));
     }
 
     @Test


### PR DESCRIPTION
This adds handling for [flash attributes](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-methods/flash-attributes.html) via `RedirectAttributes`. Now you can perform client-side redirects with htmx and the flash attributes work as with normal redirects.

Fixes #96