### PR TITLE
Make use of fragment rendering available in Framework 6.2 / Boot 3.4

### DIFF
--- a/htmx-spring-boot-thymeleaf/pom.xml
+++ b/htmx-spring-boot-thymeleaf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.wimdeblauwe</groupId>
         <artifactId>htmx-spring-boot-parent</artifactId>
-        <version>3.6.1</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>htmx-spring-boot-thymeleaf</artifactId>

--- a/htmx-spring-boot/pom.xml
+++ b/htmx-spring-boot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.wimdeblauwe</groupId>
         <artifactId>htmx-spring-boot-parent</artifactId>
-        <version>3.6.1</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>htmx-spring-boot</artifactId>

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
@@ -63,7 +63,7 @@ public class HtmxMvcAutoConfiguration implements WebMvcRegistrations, WebMvcConf
     @Override
     public void addReturnValueHandlers(List<HandlerMethodReturnValueHandler> handlers) {
         handlers.add(new HtmxResponseHandlerMethodReturnValueHandler(viewResolverObjectFactory.getObject(), localeResolverObjectFactory, objectMapper));
-        handlers.add(new HtmxViewMethodReturnValueHandler(viewResolverObjectFactory.getObject(), localeResolverObjectFactory.getObject()));
+        handlers.add(new HtmxViewMethodReturnValueHandler());
     }
 
     @Bean

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewMethodReturnValueHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxViewMethodReturnValueHandler.java
@@ -1,29 +1,12 @@
 package io.github.wimdeblauwe.htmx.spring.boot.mvc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.MethodParameter;
-import org.springframework.lang.Nullable;
-import org.springframework.ui.ModelMap;
-import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
-import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.springframework.web.servlet.view.FragmentsRendering;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Handles return values that are of type {@link HtmxView}.
@@ -31,14 +14,6 @@ import java.util.stream.Collectors;
  * @since 3.6.0
  */
 public class HtmxViewMethodReturnValueHandler implements HandlerMethodReturnValueHandler {
-
-    private final ViewResolver viewResolver;
-    private final LocaleResolver localeResolver;
-
-    public HtmxViewMethodReturnValueHandler(ViewResolver viewResolver, LocaleResolver localeResolver) {
-        this.viewResolver = viewResolver;
-        this.localeResolver = localeResolver;
-    }
 
     @Override
     public boolean supportsReturnType(MethodParameter returnType) {
@@ -59,33 +34,6 @@ public class HtmxViewMethodReturnValueHandler implements HandlerMethodReturnValu
     }
 
     private View toView(HtmxView htmxView) {
-
-        return (model, request, response) -> {
-            Locale locale = localeResolver.resolveLocale(request);
-            ContentCachingResponseWrapper wrapper = new ContentCachingResponseWrapper(response);
-
-            for (ModelAndView mav : htmxView.getViews()) {
-                View view;
-                if (mav.isReference()) {
-                    view = viewResolver.resolveViewName(mav.getViewName(), locale);
-                    if (view == null) {
-                        throw new IllegalArgumentException("Could not resolve view with name '" + mav.getViewName() + "'.");
-                    }
-                } else {
-                    view = mav.getView();
-                }
-
-                for (String key : model.keySet()) {
-                    if (!mav.getModel().containsKey(key)) {
-                        mav.getModel().put(key, model.get(key));
-                    }
-                }
-
-                view.render(mav.getModel(), request, wrapper);
-            }
-
-            wrapper.copyBodyToResponse();
-        };
+        return FragmentsRendering.with(htmxView.getViews()).build();
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.github.wimdeblauwe</groupId>
     <artifactId>htmx-spring-boot-parent</artifactId>
-    <version>3.6.1</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Parent of Spring Boot library for htmx</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
The new `FragmentRendering` API allows us to get rid of the custom, manual rendering of the fragments. Test are all good after the refactoring.

## Related tickets
* GH-148
