### PR TITLE
Add support for native HTMX redirects in Spring Security

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAccessDeniedHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAccessDeniedHandler.java
@@ -1,0 +1,61 @@
+package io.github.wimdeblauwe.htmx.spring.boot.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.WebAttributes;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+
+/**
+ * Handles navigation on {@link HttpStatus#FORBIDDEN} access by delegating to the {@link HxLocationRedirectStrategy},
+ * providing an HTMX-friendly redirect mechanism.
+ * <p>
+ * This class is not used by the library itself, but users of the library can use it to configure their security for
+ * native htmx redirects.
+ * <p>
+ * For detailed information and an example of how to integrate this into the {@link SecurityFilterChain} bean
+ * definition, see the <a href="https://github.com/lcnicolau/cs50-todo-list?tab=readme-ov-file#htmx-redirect-pattern">
+ * HTMX Redirect Pattern</a>.
+ *
+ * @author LC Nicolau
+ * @see HxLocationRedirectAuthenticationEntryPoint
+ * @see HxLocationRedirectAuthenticationSuccessHandler
+ * @see HxLocationRedirectLogoutSuccessHandler
+ */
+public class HxLocationRedirectAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final String redirectUrl;
+    private final boolean storeInSession;
+    private final RedirectStrategy redirectStrategy;
+
+    public HxLocationRedirectAccessDeniedHandler(String redirectUrl) {
+        this(redirectUrl, true);
+    }
+
+    public HxLocationRedirectAccessDeniedHandler(String redirectUrl, boolean storeInSession) {
+        this(redirectUrl, storeInSession, new HxLocationRedirectStrategy(HttpStatus.FORBIDDEN));
+    }
+
+    public HxLocationRedirectAccessDeniedHandler(String redirectUrl, boolean storeInSession, RedirectStrategy redirectStrategy) {
+        this.redirectUrl = redirectUrl;
+        this.storeInSession = storeInSession;
+        this.redirectStrategy = redirectStrategy;
+    }
+
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        if (storeInSession) {
+            request.getSession().setAttribute(WebAttributes.ACCESS_DENIED_403, accessDeniedException);
+        }
+        redirectStrategy.sendRedirect(request, response, redirectUrl);
+    }
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAuthenticationEntryPoint.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAuthenticationEntryPoint.java
@@ -1,0 +1,61 @@
+package io.github.wimdeblauwe.htmx.spring.boot.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.WebAttributes;
+
+import java.io.IOException;
+
+
+/**
+ * Handles navigation on {@link HttpStatus#UNAUTHORIZED} access by delegating to the {@link HxLocationRedirectStrategy},
+ * providing an HTMX-friendly redirect mechanism.
+ * <p>
+ * This class is not used by the library itself, but users of the library can use it to configure their security for
+ * native htmx redirects.
+ * <p>
+ * For detailed information and an example of how to integrate this into the {@link SecurityFilterChain} bean
+ * definition, see the <a href="https://github.com/lcnicolau/cs50-todo-list?tab=readme-ov-file#htmx-redirect-pattern">
+ * HTMX Redirect Pattern</a>.
+ *
+ * @author LC Nicolau
+ * @see HxLocationRedirectAccessDeniedHandler
+ * @see HxLocationRedirectAuthenticationSuccessHandler
+ * @see HxLocationRedirectLogoutSuccessHandler
+ */
+public class HxLocationRedirectAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final String redirectUrl;
+    private final boolean storeInSession;
+    private final RedirectStrategy redirectStrategy;
+
+    public HxLocationRedirectAuthenticationEntryPoint(String redirectUrl) {
+        this(redirectUrl, true);
+    }
+
+    public HxLocationRedirectAuthenticationEntryPoint(String redirectUrl, boolean storeInSession) {
+        this(redirectUrl, storeInSession, new HxLocationRedirectStrategy(HttpStatus.UNAUTHORIZED));
+    }
+
+    public HxLocationRedirectAuthenticationEntryPoint(String redirectUrl, boolean storeInSession, RedirectStrategy redirectStrategy) {
+        this.redirectUrl = redirectUrl;
+        this.storeInSession = storeInSession;
+        this.redirectStrategy = redirectStrategy;
+    }
+
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        if (storeInSession) {
+            request.getSession().setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, authException);
+        }
+        redirectStrategy.sendRedirect(request, response, redirectUrl);
+    }
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAuthenticationSuccessHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectAuthenticationSuccessHandler.java
@@ -1,0 +1,57 @@
+package io.github.wimdeblauwe.htmx.spring.boot.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+
+/**
+ * Handles post-authentication navigation by delegating to the {@link SavedRequestAwareAuthenticationSuccessHandler},
+ * using {@link HxLocationRedirectStrategy} to provide an HTMX-friendly redirect mechanism.
+ * <p>
+ * This class is not used by the library itself, but users of the library can use it to configure their security for
+ * native htmx redirects.
+ * <p>
+ * For detailed information and an example of how to integrate this into the {@link SecurityFilterChain} bean
+ * definition, see the <a href="https://github.com/lcnicolau/cs50-todo-list?tab=readme-ov-file#htmx-redirect-pattern">
+ * HTMX Redirect Pattern</a>.
+ *
+ * @author LC Nicolau
+ * @see HxLocationRedirectAccessDeniedHandler
+ * @see HxLocationRedirectAuthenticationEntryPoint
+ * @see HxLocationRedirectLogoutSuccessHandler
+ */
+public class HxLocationRedirectAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final AuthenticationSuccessHandler delegate;
+
+    public HxLocationRedirectAuthenticationSuccessHandler(String defaultSuccessUrl) {
+        this(defaultSuccessUrl, false);
+    }
+
+    public HxLocationRedirectAuthenticationSuccessHandler(String defaultSuccessUrl, boolean alwaysUse) {
+        this(defaultSuccessUrl, alwaysUse, new HxLocationRedirectStrategy());
+    }
+
+    public HxLocationRedirectAuthenticationSuccessHandler(String defaultSuccessUrl, boolean alwaysUse, RedirectStrategy redirectStrategy) {
+        var handler = new SavedRequestAwareAuthenticationSuccessHandler();
+        handler.setDefaultTargetUrl(defaultSuccessUrl);
+        handler.setAlwaysUseDefaultTargetUrl(alwaysUse);
+        handler.setRedirectStrategy(redirectStrategy);
+        this.delegate = handler;
+    }
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        delegate.onAuthenticationSuccess(request, response, authentication);
+    }
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectLogoutSuccessHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectLogoutSuccessHandler.java
@@ -1,0 +1,52 @@
+package io.github.wimdeblauwe.htmx.spring.boot.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+
+import java.io.IOException;
+
+
+/**
+ * Handles post-logout navigation by delegating to the {@link SimpleUrlLogoutSuccessHandler}, using
+ * {@link HxLocationRedirectStrategy} to provide an HTMX-friendly redirect mechanism.
+ * <p>
+ * This class is not used by the library itself, but users of the library can use it to configure their security for
+ * native htmx redirects.
+ * <p>
+ * For detailed information and an example of how to integrate this into the {@link SecurityFilterChain} bean
+ * definition, see the <a href="https://github.com/lcnicolau/cs50-todo-list?tab=readme-ov-file#htmx-redirect-pattern">
+ * HTMX Redirect Pattern</a>.
+ *
+ * @author LC Nicolau
+ * @see HxLocationRedirectAccessDeniedHandler
+ * @see HxLocationRedirectAuthenticationEntryPoint
+ * @see HxLocationRedirectAuthenticationSuccessHandler
+ */
+public class HxLocationRedirectLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final LogoutSuccessHandler delegate;
+
+    public HxLocationRedirectLogoutSuccessHandler(String logoutSuccessUrl) {
+        this(logoutSuccessUrl, new HxLocationRedirectStrategy());
+    }
+
+    public HxLocationRedirectLogoutSuccessHandler(String logoutSuccessUrl, RedirectStrategy redirectStrategy) {
+        var handler = new SimpleUrlLogoutSuccessHandler();
+        handler.setDefaultTargetUrl(logoutSuccessUrl);
+        handler.setRedirectStrategy(redirectStrategy);
+        this.delegate = handler;
+    }
+
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        delegate.onLogoutSuccess(request, response, authentication);
+    }
+
+}

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectStrategy.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/security/HxLocationRedirectStrategy.java
@@ -1,0 +1,109 @@
+package io.github.wimdeblauwe.htmx.spring.boot.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxLocation;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxRequestHeader.HX_BOOSTED;
+import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxRequestHeader.HX_REQUEST;
+import static io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponseHeader.HX_LOCATION;
+import static org.springframework.http.HttpStatus.OK;
+
+
+/**
+ * HTMX-friendly redirect strategy to be used with any security handler that performs redirects.
+ * <p>
+ * When instantiated by the default constructor, it checks for HTMX requests and responds with {@link HttpStatus#OK},
+ * including the target URL in the {@link HtmxResponseHeader#HX_LOCATION} header.
+ * <p>
+ * It also sets the {@code headers} and {@code target} parameters, instructing the client to include the
+ * {@code HX-Boosted} header in the new request, and to swap the response into the {@code body} element.
+ * <p>
+ * Example:
+ * <pre> {@code
+ * hx-location: {
+ *      "path":"/login?unauthorized",
+ *      "headers":{"HX-Boosted":"true"},
+ *      "target":"body"
+ * }
+ * } </pre>
+ * <p>
+ * These parameters are useful if you want to take advantage of existing controller optimizations, to render a fragment
+ * instead of the full page for non-boosted, HTMX-driven requests:
+ * <p>
+ * <pre> {@code
+ * @GetMapping("/login")
+ * String login(HtmxRequest request) {
+ *     return request.isHtmxRequest() && !request.isBoosted()
+ *             ? "pages/login :: content"
+ *             : "pages/login";
+ * }
+ * } </pre>
+ * <p>
+ * You can override this behavior and change the response status code through the constructor.
+ * <p>
+ * For non-HTMX requests, it delegates to the {@link DefaultRedirectStrategy}.
+ *
+ * @author LC Nicolau
+ * @see <a href="https://htmx.org/headers/hx-location/">HX-Location Response Header</a>
+ * @see <a href="https://htmx.org/reference/#headers">HTTP Header Reference</a>
+ */
+class HxLocationRedirectStrategy implements RedirectStrategy {
+
+    private final boolean redirectAsBoosted;
+    private final HttpStatus status;
+
+    private final RedirectStrategy delegate = new DefaultRedirectStrategy();
+    private final JsonMapper jsonMapper = new JsonMapper();
+
+    HxLocationRedirectStrategy() {
+        this(true, OK);
+    }
+
+    HxLocationRedirectStrategy(boolean redirectAsBoosted) {
+        this(redirectAsBoosted, OK);
+    }
+
+    HxLocationRedirectStrategy(HttpStatus status) {
+        this(true, status);
+    }
+
+    HxLocationRedirectStrategy(boolean redirectAsBoosted, HttpStatus status) {
+        this.redirectAsBoosted = redirectAsBoosted;
+        this.status = status;
+    }
+
+
+    @Override
+    public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
+        if (request.getHeader(HX_REQUEST.getValue()) == null) {
+            delegate.sendRedirect(request, response, url);
+        } else {
+            this.sendLocationRedirect(request, response, url);
+        }
+    }
+
+    private void sendLocationRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
+        var location = redirectAsBoosted ? boosted(url) : url;
+        response.setHeader(HX_LOCATION.getValue(), location);
+        response.setStatus(status.value());
+        response.getWriter().flush();
+    }
+
+    private String boosted(String url) throws JsonProcessingException {
+        HtmxLocation location = new HtmxLocation(url);
+        location.setTarget("body");
+        location.setHeaders(Map.of(HX_BOOSTED.getValue(), "true"));
+        return jsonMapper.writeValueAsString(location);
+    }
+
+}


### PR DESCRIPTION
For detailed information, see: https://github.com/lcnicolau/cs50-todo-list?tab=readme-ov-file#htmx-redirect-pattern

Usage example:

```java
@Configuration
class SecurityConfig {

    @Bean
    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
        return http
                .formLogin(login -> login
                        .usernameParameter("email")
                        .loginPage("/login")
                        .failureForwardUrl("/error?login")
                        .successHandler(new HxLocationRedirectAuthenticationSuccessHandler("/tasks?login", true))
                ).logout(logout -> logout
                        .logoutSuccessHandler(new HxLocationRedirectLogoutSuccessHandler("/home?logout"))
                ).exceptionHandling(handler -> handler
                        .authenticationEntryPoint(new HxLocationRedirectAuthenticationEntryPoint("/login?unauthorized"))
                        .accessDeniedHandler(new HxLocationRedirectAccessDeniedHandler("/error?forbidden"))
                ).authorizeHttpRequests(config -> config
                        .requestMatchers(
                                toStaticResources().atCommonLocations().excluding(JAVA_SCRIPT)
                        ).permitAll()
                        .requestMatchers(
                                "/",
                                "/home",
                                "/about",
                                "/signup",
                                "/login",
                                "/error"
                        ).permitAll()
                        .requestMatchers("/users/**").hasRole("ADMIN")
                        .anyRequest().authenticated()
                )
                .cors(Customizer.withDefaults())
                .csrf(Customizer.withDefaults())
                .build();
    }

}
```