### PR TITLE
Allow @HxRequest to ignore restore history requests and ignore them by default

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxRequestMappingHandlerMapping.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxRequestMappingHandlerMapping.java
@@ -55,6 +55,11 @@ public class HtmxRequestMappingHandlerMapping extends RequestMappingHandlerMappi
             conditions.add(new HeadersRequestCondition("!" + HX_BOOSTED.getValue()));
         }
 
+        if (!hxRequest.historyRestoreRequest()) {
+            // exclude history restore requests by checking whether the header is absent
+            conditions.add(new HeadersRequestCondition("!" + HX_HISTORY_RESTORE_REQUEST.getValue()));
+        }
+
         return new CompositeRequestCondition(conditions.toArray(RequestCondition[]::new));
     }
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRequest.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxRequest.java
@@ -22,6 +22,14 @@ public @interface HxRequest {
     boolean boosted() default true;
 
     /**
+     * Whether the mapping applies also for requests that have been made for history restoration.
+     *
+     * @see <a href="https://htmx.org/reference/#request_headers">HX-History-Restore-Request</a>
+     * @since 4.1.0
+     */
+    boolean historyRestoreRequest() default false;
+
+    /**
      * Restricts the mapping to the {@code id} of a specific target element.
      *
      * @see <a href="https://htmx.org/reference/#request_headers">HX-Target</a>

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxRequestMappingHandlerMappingTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxRequestMappingHandlerMappingTest.java
@@ -48,6 +48,23 @@ public class HtmxRequestMappingHandlerMappingTest {
     }
 
     @Test
+    void testHxRequestShouldHandleHistoryRestoreRequest() throws Exception {
+        mockMvc.perform(get("/hx-request-handle-history-restore-request")
+                                .header(HX_REQUEST.getValue(), "true")
+                                .header(HX_HISTORY_RESTORE_REQUEST.getValue(), "true"))
+               .andExpect(status().isOk())
+               .andExpect(content().string("history-restore-request-handled"));
+    }
+
+    @Test
+    void testHxRequestShouldIgnoreHistoryRestoreRequest() throws Exception {
+        mockMvc.perform(get("/hx-request")
+                                .header(HX_REQUEST.getValue(), "true")
+                                .header(HX_HISTORY_RESTORE_REQUEST.getValue(), "true"))
+               .andExpect(status().isNotFound());
+    }
+
+    @Test
     void testHxRequestTargetBar() throws Exception {
         mockMvc.perform(get("/hx-request-target")
                                 .header(HX_REQUEST.getValue(), "true")
@@ -153,6 +170,13 @@ public class HtmxRequestMappingHandlerMappingTest {
         @ResponseBody
         public String hxRequestIgnoreBoosted() {
             return "boosted-ignored";
+        }
+
+        @HxRequest(historyRestoreRequest = true)
+        @GetMapping("/hx-request-handle-history-restore-request")
+        @ResponseBody
+        public String hxRequestHandleHistoryRestoreRequest() {
+            return "history-restore-request-handled";
         }
 
         @HxRequest(target = "bar")


### PR DESCRIPTION
This adds a new annotation parameter `historyRestoreRequest` to `@HxRequest` to control whether the mapping should be applied to requests made for History Restore Requests.

By default, the mapping is not applied to history restore requests.

Resolves #170.