### PR TITLE
[fix] autoconfiguration not limited to servlet-based web application

### DIFF
--- a/htmx-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/thymeleaf/HtmxThymeleafAutoConfiguration.java
+++ b/htmx-spring-boot-thymeleaf/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/thymeleaf/HtmxThymeleafAutoConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import tools.jackson.databind.json.JsonMapper;
 
 @AutoConfiguration
-@ConditionalOnWebApplication
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class HtmxThymeleafAutoConfiguration {
 
     @Bean

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxMvcAutoConfiguration.java
@@ -18,7 +18,7 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.List;
 
 @AutoConfiguration
-@ConditionalOnWebApplication
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class HtmxMvcAutoConfiguration implements WebMvcRegistrations, WebMvcConfigurer {
 
     private final HtmxHandlerMethodHandler handlerMethodHandler;


### PR DESCRIPTION
As mentioned in #167, we should ensure that the library is limited to servlet-based web applications only.