### PR TITLE
Make swap style optional and add support to define “none” for scroll and show in HX-Reswap

### DIFF
--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerMethodHandler.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerMethodHandler.java
@@ -191,6 +191,7 @@ class HtmxHandlerMethodHandler {
 
     private HtmxReswap.Position convertToPosition(HxReswap.Position position) {
         return switch (position) {
+            case NONE -> HtmxReswap.Position.NONE;
             case TOP -> HtmxReswap.Position.TOP;
             case BOTTOM -> HtmxReswap.Position.BOTTOM;
             default -> throw new IllegalStateException("Unexpected value: " + position);

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxReswap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxReswap.java
@@ -22,6 +22,14 @@ public class HtmxReswap {
     private Boolean focusScroll;
 
     /**
+     * Use the default swap behavior as configured by {@code htmx.config.defaultSwapStyle}
+     * or {@code innerHTML} for boosted requests.
+     */
+    public static HtmxReswap defaultSwap() {
+        return new HtmxReswap(HxSwapType.DEFAULT);
+    }
+
+    /**
      * Insert the response before the first child of the target element.
      */
     public static HtmxReswap afterBegin() {
@@ -154,7 +162,7 @@ public class HtmxReswap {
             }
         }
 
-        return value.toString();
+        return value.toString().trim();
     }
 
     /**

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxReswap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxReswap.java
@@ -148,14 +148,14 @@ public class HtmxReswap {
             value.append(" settle:").append(settle.toMillis()).append("ms");
         }
         if (scroll != null) {
-            if (scrollTarget != null) {
+            if (scroll != Position.NONE && scrollTarget != null) {
                 value.append(" scroll:").append(scrollTarget).append(":").append(scroll.getValue());
             } else {
                 value.append(" scroll:").append(scroll.getValue());
             }
         }
         if (show != null) {
-            if (showTarget != null) {
+            if (show != Position.NONE && showTarget != null) {
                 value.append(" show:").append(showTarget).append(":").append(show.getValue());
             } else {
                 value.append(" show:").append(show.getValue());
@@ -282,6 +282,7 @@ public class HtmxReswap {
      */
     public enum Position {
 
+        NONE("none"),
         TOP("top"),
         BOTTOM("bottom");
 

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
@@ -16,11 +16,12 @@ import java.lang.annotation.Target;
 public @interface HxReswap {
 
     /**
-     * A value to specify how the response will be swapped.
+     * A value to specify how the response will be swapped. The default value is {@link HxSwapType#DEFAULT}
+     * which uses the default swap behavior as configured by {@code htmx.config.defaultSwapStyle}
      *
      * @see <a href="https://htmx.org/attributes/hx-swap/">hx-swap</a>
      */
-    HxSwapType value() default HxSwapType.INNER_HTML;
+    HxSwapType value() default HxSwapType.DEFAULT;
 
     /**
      * Set the time in milliseconds that should elapse after receiving a response to swap the content.

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxReswap.java
@@ -78,6 +78,7 @@ public @interface HxReswap {
      * Represents the position values for {@link #show()} and {@link #scroll()}
      */
     public enum Position {
+        NONE,
         TOP,
         BOTTOM,
         UNDEFINED

--- a/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxSwapType.java
+++ b/htmx-spring-boot/src/main/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HxSwapType.java
@@ -7,13 +7,42 @@ package io.github.wimdeblauwe.htmx.spring.boot.mvc;
  */
 public enum HxSwapType {
 
+    /**
+     * Use the default swap behavior as configured by {@code htmx.config.defaultSwapStyle}
+     * or {@code innerHTML} for boosted requests.
+     */
+    DEFAULT(""),
+    /**
+     * Replace the inner html of the target element.
+     */
     INNER_HTML("innerHTML"),
+    /**
+     * Replace the entire target element with the response.
+     */
     OUTER_HTML("outerHTML"),
+    /**
+     * Insert the response before the target element.
+     */
     BEFORE_BEGIN("beforebegin"),
+    /**
+     * Insert the response before the first child of the target element.
+     */
     AFTER_BEGIN("afterbegin"),
+    /**
+     * Insert the response after the last child of the target element.
+     */
     BEFORE_END("beforeend"),
+    /**
+     * Insert the response after the target element.
+     */
     AFTER_END("afterend"),
+    /**
+     * Deletes the target element regardless of the response.
+     */
     DELETE("delete"),
+    /**
+     * Does not append the response to target element (out of band items will still be processed).
+     */
     NONE("none");
 
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -175,6 +175,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxReswapDefaultWithSwapTiming() throws Exception {
+        mockMvc.perform(get("/hx-reswap-default-with-swap-timing"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reswap", "swap:0ms"));
+    }
+
+    @Test
     public void testHxRetarget() throws Exception {
         mockMvc.perform(get("/hx-retarget"))
                .andExpect(status().isOk())
@@ -323,6 +330,13 @@ class HtmxHandlerInterceptorTest {
                 focusScroll = HxReswap.FocusScroll.TRUE)
         @ResponseBody
         public String hxReswap() {
+            return "";
+        }
+
+        @GetMapping("/hx-reswap-default-with-swap-timing")
+        @HxReswap(value = HxSwapType.DEFAULT, swap = 0)
+        @ResponseBody
+        public String hxReswapDefaultWithSwapTiming() {
             return "";
         }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxHandlerInterceptorTest.java
@@ -182,6 +182,13 @@ class HtmxHandlerInterceptorTest {
     }
 
     @Test
+    public void testHxReswapShowNone() throws Exception {
+        mockMvc.perform(get("/hx-reswap-show-none"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reswap", "show:none"));
+    }
+
+    @Test
     public void testHxRetarget() throws Exception {
         mockMvc.perform(get("/hx-retarget"))
                .andExpect(status().isOk())
@@ -337,6 +344,13 @@ class HtmxHandlerInterceptorTest {
         @HxReswap(value = HxSwapType.DEFAULT, swap = 0)
         @ResponseBody
         public String hxReswapDefaultWithSwapTiming() {
+            return "";
+        }
+
+        @GetMapping("/hx-reswap-show-none")
+        @HxReswap(show = HxReswap.Position.NONE)
+        @ResponseBody
+        public String hxReswapShowNone() {
             return "";
         }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverIT.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverIT.java
@@ -136,6 +136,14 @@ public class HtmxResponseHandlerMethodArgumentResolverIT {
     }
 
     @Test
+    public void testReswapShowNone() throws Exception {
+
+        get("/reswap-show-none")
+                .expectHeader()
+                .valueEquals("HX-Reswap", "show:none");
+    }
+
+    @Test
     public void testRetarget() throws Exception {
 
         get("/retarget")
@@ -294,6 +302,14 @@ public class HtmxResponseHandlerMethodArgumentResolverIT {
 
             response.setReswap(HtmxReswap.defaultSwap()
                                          .swap(Duration.ZERO));
+            return "view";
+        }
+
+        @GetMapping("/reswap-show-none")
+        public String reswapShowNone(HtmxResponse response) {
+
+            response.setReswap(HtmxReswap.defaultSwap()
+                                         .show(HtmxReswap.Position.NONE));
             return "view";
         }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverIT.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverIT.java
@@ -128,6 +128,14 @@ public class HtmxResponseHandlerMethodArgumentResolverIT {
     }
 
     @Test
+    public void testReswapDefaultWithSwapTiming() throws Exception {
+
+        get("/reswap-default-with-swap-timing")
+                .expectHeader()
+                .valueEquals("HX-Reswap", "swap:0ms");
+    }
+
+    @Test
     public void testRetarget() throws Exception {
 
         get("/retarget")
@@ -278,6 +286,14 @@ public class HtmxResponseHandlerMethodArgumentResolverIT {
         public String reswapOuterHtml(HtmxResponse response) {
 
             response.setReswap(HtmxReswap.outerHtml());
+            return "view";
+        }
+
+        @GetMapping("/reswap-default-with-swap-timing")
+        public String reswapDefaultWithSwapTiming(HtmxResponse response) {
+
+            response.setReswap(HtmxReswap.defaultSwap()
+                                         .swap(Duration.ZERO));
             return "view";
         }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverTest.java
@@ -149,6 +149,14 @@ public class HtmxResponseHandlerMethodArgumentResolverTest {
     }
 
     @Test
+    public void testReswapShowNone() throws Exception {
+
+        mockMvc.perform(get("/reswap-show-none"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reswap", "show:none"));
+    }
+
+    @Test
     public void testRetarget() throws Exception {
 
         mockMvc.perform(get("/retarget"))
@@ -296,6 +304,14 @@ public class HtmxResponseHandlerMethodArgumentResolverTest {
 
             response.setReswap(HtmxReswap.defaultSwap()
                                          .swap(Duration.ZERO));
+            return "view";
+        }
+
+        @GetMapping("/reswap-show-none")
+        public String reswapShowNone(HtmxResponse response) {
+
+            response.setReswap(HtmxReswap.defaultSwap()
+                                         .show(HtmxReswap.Position.NONE));
             return "view";
         }
 

--- a/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverTest.java
+++ b/htmx-spring-boot/src/test/java/io/github/wimdeblauwe/htmx/spring/boot/mvc/HtmxResponseHandlerMethodArgumentResolverTest.java
@@ -141,6 +141,14 @@ public class HtmxResponseHandlerMethodArgumentResolverTest {
     }
 
     @Test
+    public void testReswapDefaultWithSwapTiming() throws Exception {
+
+        mockMvc.perform( get("/reswap-default-with-swap-timing"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("HX-Reswap", "swap:0ms"));
+    }
+
+    @Test
     public void testRetarget() throws Exception {
 
         mockMvc.perform(get("/retarget"))
@@ -280,6 +288,14 @@ public class HtmxResponseHandlerMethodArgumentResolverTest {
         public String reswapOuterHtml(HtmxResponse response) {
 
             response.setReswap(HtmxReswap.outerHtml());
+            return "view";
+        }
+
+        @GetMapping("/reswap-default-with-swap-timing")
+        public String reswapDefaultWithSwapTiming(HtmxResponse response) {
+
+            response.setReswap(HtmxReswap.defaultSwap()
+                                         .swap(Duration.ZERO));
             return "view";
         }
 


### PR DESCRIPTION
The first commit makes the swap style in the `HX-Reswap` header optional, meaning it defaults to the swap style configured in `htmx.config.defaultSwapStyle`. The `@HxReswap` annotation now uses this as the default, whereas `HtmxReswap` can be created using `HtmxReswap.defaultSwap()`.

The second commit fixes #190.

**Examples**
```java
@GetMapping("/example")
@HxReswap(show = HxReswap.Position.NONE)
public String example() {
  ...
}
```

```java
@GetMapping("/example")
public String example(HtmxResponse response) {
   response.setReswap(HtmxReswap.defaultSwap().show(HtmxReswap.Position.NONE));
   ...
}
```